### PR TITLE
fix: convert gcp secret to string before returning

### DIFF
--- a/pkg/backends/gcpsecretmanager.go
+++ b/pkg/backends/gcpsecretmanager.go
@@ -59,7 +59,7 @@ func (a *GCPSecretManager) GetSecrets(path string, version string, annotations m
 
 	secretName := matches[GCPPath.SubexpIndex("secretid")]
 	secretData := result.Payload.Data
-	data[secretName] = secretData
+	data[secretName] = string(secretData)
 
 	return data, nil
 }

--- a/pkg/backends/gcpsecretmanager_test.go
+++ b/pkg/backends/gcpsecretmanager_test.go
@@ -1,13 +1,14 @@
 package backends_test
 
 import (
+	"reflect"
+	"strings"
+	"testing"
+
 	"github.com/IBM/argocd-vault-plugin/pkg/backends"
 	"github.com/googleapis/gax-go/v2"
 	"golang.org/x/net/context"
 	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
-	"reflect"
-	"strings"
-	"testing"
 )
 
 type mockSecretManagerClient struct {
@@ -51,7 +52,7 @@ func TestGCPSecretManagerGetSecrets(t *testing.T) {
 
 		// Data correct
 		expected := map[string]interface{}{
-			"test-secret": []byte("some-value"),
+			"test-secret": "some-value",
 		}
 
 		if !reflect.DeepEqual(expected, data) {
@@ -65,7 +66,7 @@ func TestGCPSecretManagerGetSecrets(t *testing.T) {
 			t.Fatalf("expected 0 errors but got: %s", err)
 		}
 
-		expected := []byte("some-value")
+		expected := "some-value"
 
 		if !reflect.DeepEqual(expected, secret) {
 			t.Errorf("expected: %s, got: %s", expected, secret)
@@ -86,7 +87,7 @@ func TestGCPSecretManagerGetSecrets(t *testing.T) {
 
 		// Data correct
 		expected := map[string]interface{}{
-			"test-secret": []byte("v3-value"),
+			"test-secret": "v3-value",
 		}
 		if !reflect.DeepEqual(expected, data) {
 			t.Errorf("expected: %s, got: %s.", expected, data)


### PR DESCRIPTION
### Description
GCP was always returning base64 value, this change will fix that and just return whatever value is in GCP

**Fixes:** #213 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Docs have been added / updated

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
