### PR TITLE
feat: Cache data from IBM SM within invocation

### DIFF
--- a/pkg/backends/ibmsecretsmanager.go
+++ b/pkg/backends/ibmsecretsmanager.go
@@ -10,7 +10,7 @@ import (
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/types"
 )
 
-var IBMPath, _ = regexp.Compile(`ibmcloud/(?P<type>.+)/secrets/groups/(?P<groupid>.+)`)
+var IBMPath, _ = regexp.Compile(`ibmcloud/(?P<type>.+)/secrets/groups/(?P<groupId>.+)`)
 
 // IBMSecretsManagerClient is an interface for any client to the IBM Secrets Manager
 // These are only the methods we need
@@ -20,17 +20,75 @@ type IBMSecretsManagerClient interface {
 	GetSecretVersion(getSecretOptions *ibmsm.GetSecretVersionOptions) (result *ibmsm.GetSecretVersion, response *core.DetailedResponse, err error)
 }
 
+// Used as the key into the several caches for IBM SM API calls
+// Includes groupId and secretType since secrets are unique by group, type, and their name
+type cacheKey struct {
+	groupId    string
+	secretType string
+}
+
 // IBMSecretsManager is a struct for working with IBM Secret Manager
 type IBMSecretsManager struct {
 	Client IBMSecretsManagerClient
+
+	// Cache for storing *ibmsm.SecretResource's from listing the secrets of a group
+	// Organized as:
+	// [groupId]: { [secretType]: { [secretName]: &ibmsm.SecretResource } }
+	// Only read/written to by the main goroutine, no synchronized access needed
+	listAllSecretsCache map[cacheKey]map[string]*ibmsm.SecretResource
+
+	// Cache for storing payloads (interface{}) of secrets
+	// Organized as:
+	// [groupId]: { [secretType]: { [secretName]: interface{} } }
+	// We don't keep track of the secret version since most secrets aren't versionable in IBM SM anyway,
+	// so this cache should not be used to retrieve a secret with a specific version
+	// Written to by the `i.getSecrets` goroutines, synchronized access provided by getSecretsCacheLock
+	getSecretsCache map[cacheKey]map[string]interface{}
+
+	getSecretsCacheLock sync.RWMutex
+
+	// Keeps track of whether GetSecrets has been called for a given group and secret type
+	// Only read/written to by the main goroutine, no synchronized access needed
+	retrievedAllSecrets map[cacheKey]bool
 }
 
 // NewIBMSecretsManagerBackend initializes a new IBM Secret Manager backend
 func NewIBMSecretsManagerBackend(client IBMSecretsManagerClient) *IBMSecretsManager {
 	ibmSecretsManager := &IBMSecretsManager{
-		Client: client,
+		Client:              client,
+		listAllSecretsCache: make(map[cacheKey]map[string]*ibmsm.SecretResource),
+		getSecretsCache:     make(map[cacheKey]map[string]interface{}),
+		retrievedAllSecrets: make(map[cacheKey]bool),
 	}
 	return ibmSecretsManager
+}
+
+// parsePath returns the groupId, secretType represented by the path
+func parsePath(path string) (string, string, error) {
+	matches := IBMPath.FindStringSubmatch(path)
+	if len(matches) == 0 {
+		return "", "", fmt.Errorf("Path is not in the correct format (ibmcloud/$TYPE/secrets/groups/$GROUP_ID) for IBM Secrets Manager: %s", path)
+	}
+	return matches[IBMPath.SubexpIndex("type")], matches[IBMPath.SubexpIndex("groupId")], nil
+}
+
+func (i *IBMSecretsManager) readSecretFromCache(groupId, secretType, secretName string) interface{} {
+	result := i.getSecretsCache[cacheKey{groupId, secretType}]
+	if result != nil {
+		return result[secretName]
+	}
+	return nil
+}
+
+func (i *IBMSecretsManager) writeSecretToCache(groupId, secretType, secretName string, payload interface{}) {
+	ckey := cacheKey{groupId, secretType}
+	if i.getSecretsCache[ckey] != nil {
+		i.getSecretsCache[ckey][secretName] = payload
+	} else {
+		i.getSecretsCache[ckey] = map[string]interface{}{
+			secretName: payload,
+		}
+	}
 }
 
 // Login does nothing since the IBM Secrets Manager client is setup on instantiation
@@ -97,24 +155,100 @@ func (i *IBMSecretsManager) getSecret(secret *ibmsm.SecretResource, version stri
 	result := make(map[string]interface{})
 	result["name"] = *secret.Name
 
-	secretData, err := i.getSecretVersionedOrNot(secret, version)
-	if err != nil {
-		result["err"] = err
+	var groupId string
+	if secret.SecretGroupID == nil {
+		groupId = "default"
+	} else {
+		groupId = *(secret.SecretGroupID)
+	}
+
+	secretType := *(secret.SecretType)
+	secretName := *(secret.Name)
+
+	i.getSecretsCacheLock.RLock()
+	cacheResult := i.readSecretFromCache(groupId, secretType, secretName)
+	i.getSecretsCacheLock.RUnlock()
+
+	// Bypass the cache when explicit version is requested
+	if cacheResult != nil && version == "" {
+		result["payload"] = cacheResult
 	} else {
 
-		// Copy whatever keys this non-arbitrary secret has into a map for use with `jsonParse`
-		if secretData["payload"] == nil {
-			result["payload"] = make(map[string]interface{})
-			for k, v := range secretData {
-				(result["payload"].(map[string]interface{}))[k] = v
-			}
+		secretData, err := i.getSecretVersionedOrNot(secret, version)
+		var payload interface{}
+		if err != nil {
+			result["err"] = err
 		} else {
-			result["payload"] = secretData["payload"]
+
+			// Copy whatever keys this non-arbitrary secret has into a map for use with `jsonParse`
+			if secretData["payload"] == nil {
+				payload = make(map[string]interface{})
+				for k, v := range secretData {
+					(payload.(map[string]interface{}))[k] = v
+				}
+			} else {
+				payload = secretData["payload"]
+			}
 		}
+
+		// Populate cache if successful
+		if err == nil {
+			i.getSecretsCacheLock.Lock()
+			i.writeSecretToCache(groupId, secretType, secretName, payload)
+			i.getSecretsCacheLock.Unlock()
+		}
+
+		result["payload"] = payload
 	}
 
 	response <- result
 	wg.Done()
+}
+
+// Enumerate the secret names and their ids for the secrets of type secretType in group groupId,
+// caching results into listAllSecretsCache
+func (i *IBMSecretsManager) listSecretsInGroup(groupId, secretType string) (map[string]*ibmsm.SecretResource, error) {
+	ckey := cacheKey{groupId, secretType}
+	cachedData := i.listAllSecretsCache[ckey]
+	if cachedData != nil {
+		return cachedData, nil
+	}
+
+	var offset int64 = 0
+	for {
+		res, details, err := i.Client.ListAllSecrets(&ibmsm.ListAllSecretsOptions{
+			Groups: []string{groupId},
+			Offset: &offset,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Could not list secrets for secret group %s: %s\n%s", groupId, err, details.String())
+		}
+		if res == nil {
+			return nil, fmt.Errorf("Could not list secrets for secret group %s: %d\n%s", groupId, details.GetStatusCode(), details.String())
+		}
+
+		for _, secret := range res.Resources {
+			name := *(secret.(*ibmsm.SecretResource).Name)
+			ttype := *(secret.(*ibmsm.SecretResource).SecretType)
+			ckey := cacheKey{groupId, ttype}
+
+			if i.listAllSecretsCache[ckey] != nil {
+				i.listAllSecretsCache[ckey][name] = secret.(*ibmsm.SecretResource)
+			} else {
+				i.listAllSecretsCache[ckey] = map[string]*ibmsm.SecretResource{
+					name: secret.(*ibmsm.SecretResource),
+				}
+			}
+		}
+
+		// The IBM SM API returns a max of MAX_PER_PAGE results, so if we get that many on the first request, there might be more secrets
+		if len(res.Resources) < types.IBMMaxPerPage {
+			break
+		}
+		offset += int64(types.IBMMaxPerPage)
+	}
+
+	return i.listAllSecretsCache[ckey], nil
 }
 
 func storeSecret(secrets *map[string]interface{}, result map[string]interface{}) error {
@@ -125,39 +259,24 @@ func storeSecret(secrets *map[string]interface{}, result map[string]interface{})
 	return nil
 }
 
-// GetSecrets returns the data for the secrets of a group in IBM Secrets Manager
+// GetSecrets returns the data for all secrets of a specific type of a group in IBM Secrets Manager
 func (i *IBMSecretsManager) GetSecrets(path string, version string, annotations map[string]string) (map[string]interface{}, error) {
-	// IBM SM users pass the path of a secret _group_ which contains a list of secrets
-	// ex: <path:ibmcloud/arbitrary/secrets/groups/123#username>
-	// So we query the group to enumerate the secret ids, and retrieve each one to return a complete map of them
-	matches := IBMPath.FindStringSubmatch(path)
-	if len(matches) == 0 {
+	secretType, groupId, err := parsePath(path)
+	if err != nil {
 		return nil, fmt.Errorf("Path is not in the correct format (ibmcloud/$TYPE/secrets/groups/$GROUP_ID) for IBM Secrets Manager: %s", path)
 	}
+	ckey := cacheKey{groupId, secretType}
 
-	// Enumerate the secret names and their ids
-	// The IBM SM API returns a max of MAX_PER_PAGE results, so if we get that many on the first request, there might be more secrets
-	groupid := matches[IBMPath.SubexpIndex("groupid")]
-	var offset int64 = 0
-	var result []ibmsm.SecretResourceIntf
-	for {
-		res, details, err := i.Client.ListAllSecrets(&ibmsm.ListAllSecretsOptions{
-			Groups: []string{groupid},
-			Offset: &offset,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("Could not list secrets for secret group %s: %s\n%s", groupid, err, details.String())
-		}
-		if res == nil {
-			return nil, fmt.Errorf("Could not list secrets for secret group %s: %d\n%s", groupid, details.GetStatusCode(), details.String())
-		}
+	// Bypass the cache when explicit version is requested
+	// Otherwise, use it if applicable
+	if version == "" && i.retrievedAllSecrets[ckey] {
+		return i.getSecretsCache[ckey], nil
+	}
 
-		result = append(result, res.Resources...)
-
-		if len(res.Resources) < types.IBMMaxPerPage {
-			break
-		}
-		offset += int64(types.IBMMaxPerPage)
+	// So we query the group to enumerate the secret ids, and retrieve each one to return a complete map of them
+	result, err := i.listSecretsInGroup(groupId, secretType)
+	if err != nil {
+		return nil, err
 	}
 
 	// Using MAX_GOROUTINES at a time, retrieve the secrets of the right type from the group
@@ -167,31 +286,25 @@ func (i *IBMSecretsManager) GetSecrets(path string, version string, annotations 
 	MAX_GOROUTINES := 20
 	launchedRoutines := 0
 
-	for _, resource := range result {
-		if secret, ok := resource.(*ibmsm.SecretResource); ok {
+	for _, secret := range result {
 
-			// This check is required since secrets are only unique by name, group, _and_ type
-			if *secret.SecretType == matches[IBMPath.SubexpIndex("type")] {
-
-				// There is space for more goroutines, so spawn immediately and continue
-				if launchedRoutines < MAX_GOROUTINES {
-					go i.getSecret(secret, version, secretResult, &wg)
-					wg.Add(1)
-					launchedRoutines += 1
-					continue
-				}
-
-				// Wait for a goroutine to finish before spawning another
-				err := storeSecret(&secrets, <-secretResult)
-				if err != nil {
-					return nil, err
-				}
-
-				go i.getSecret(secret, version, secretResult, &wg)
-				wg.Add(1)
-				launchedRoutines += 1
-			}
+		// There is space for more goroutines, so spawn immediately and continue
+		if launchedRoutines < MAX_GOROUTINES {
+			go i.getSecret(secret, version, secretResult, &wg)
+			wg.Add(1)
+			launchedRoutines += 1
+			continue
 		}
+
+		// Wait for a goroutine to finish before spawning another
+		err := storeSecret(&secrets, <-secretResult)
+		if err != nil {
+			return nil, err
+		}
+
+		go i.getSecret(secret, version, secretResult, &wg)
+		wg.Add(1)
+		launchedRoutines += 1
 	}
 
 	go func() {
@@ -206,16 +319,53 @@ func (i *IBMSecretsManager) GetSecrets(path string, version string, annotations 
 		}
 	}
 
+	i.retrievedAllSecrets[ckey] = true
+
 	return secrets, nil
 }
 
 // GetIndividualSecret will get the specific secret (placeholder) from the SM backend
-// For IBM, we only support placeholders replaced from secrets in a group, which cannot be individually addressed by placeholder (secret name)
-// So, we use GetSecrets and extract the specific placeholder we want
-func (i *IBMSecretsManager) GetIndividualSecret(kvpath, secret, version string, annotations map[string]string) (interface{}, error) {
-	data, err := i.GetSecrets(kvpath, version, annotations)
+// This requires listing the secrets of the group to obtain the id, and then using that to grab the one secret's payload
+func (i *IBMSecretsManager) GetIndividualSecret(kvpath, secretName, version string, annotations map[string]string) (interface{}, error) {
+	secretType, groupId, err := parsePath(kvpath)
+	if err != nil {
+		return nil, fmt.Errorf("Path is not in the correct format (ibmcloud/$TYPE/secrets/groups/$GROUP_ID) for IBM Secrets Manager: %s", kvpath)
+	}
+	ckey := cacheKey{groupId, secretType}
+
+	// Bypass the cache when explicit version is requested
+	// If we have already retrieved all the secrets for the requested secret's group and type, we have a cache hit
+	if version == "" && i.retrievedAllSecrets[ckey] {
+		return i.getSecretsCache[ckey][secretName], nil
+	}
+
+	// Grab the *ibmsm.SecretResource corresponding to the secret
+	secretResources, err := i.listSecretsInGroup(groupId, secretType)
 	if err != nil {
 		return nil, err
 	}
-	return data[secret], nil
+	secret := secretResources[secretName]
+	if secret == nil {
+
+		// Allow the replacement code to handle this missing secret
+		return nil, nil
+	}
+
+	// Retrieve the secret's payload
+	secrets := make(map[string]interface{})
+	secretResult := make(chan map[string]interface{})
+	var wg sync.WaitGroup
+	go i.getSecret(secret, version, secretResult, &wg)
+	wg.Add(1)
+	go func() {
+		wg.Wait()
+		close(secretResult)
+	}()
+
+	err = storeSecret(&secrets, <-secretResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return secrets[secretName], nil
 }


### PR DESCRIPTION
### Description

Add caching of data in the IBM SM backend so that secrets are replaced faster. I started with this one in particular because it performs the worst: for each manifest, to replace a placeholder, the ID of the secret corresponding to that placeholder has to be retrieved and only then can the secret payload be obtained. Obtaining the payloads is currently done by getting the payloads of _all_ the secrets in a group, and filtering as needed, for _every_ inline-path placeholder. Lots of room for improvement.

The idea is to cache all API call results within an invocation of the plugin. Since every invocation of the plugin uses a specific backend configuration and we use the same backend for replacing each template, we can cache results across manifests, and across placeholders within a manifest. The cache has to be hierarchical since secrets in IBM SM are only unique by group, type, and name - so we have to keep a cache of secret-payload maps per type per group. 

The code is a proof of concept - I left some comments on the parts where I think it could use some extra scrutiny. No tests added yet. Basically every function that calls the IBM SM API is modified to a.) check the cache before performing the call, serving results from cache if applicable, and b.) populate the cache after making the call. That's why there are 2 caches: one for the results of `GET /api/v1/secrets`, which we call to determine the ID of a secret given its name, and one for the results of `GET /api/v1/secrets/{secret_type}/{id}`. 

Benchmarks provided in a comment on this PR. 

Some caveats of this as written are:

- Any requests for non-latest version of secrets bypass the cache. This means the cache is only effective for manifests with either a.) generic placeholders with no secret version annotation and/or b.) inline-path placeholders with no explicit version. I did this since most secret types in IBM SM can't be versioned. Can be fixed though.

**Fixes:** <! -- link to issue -->

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
