### PR TITLE
feat: support for go templates from an annotation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -68,3 +68,4 @@ We support several different annotations that can be used inside a kubernetes re
 | avp.kubernetes.io/kv-version | Version of the KV Secret Engine |
 | avp.kubernetes.io/secret-version | Version of the secret to retrieve. Only effective on generic `<placeholder>`s so `avp.kubernetes.io/path` is required when this annotation is used |
 | avp.kubernetes.io/remove-missing | Plugin will not throw error when a key is missing from Vault Secret. Only works on `Secret` or `ConfigMap` resources |
+| avp.kubernetes.io/data-template | A Go template used to generate and replace the contents of the manifest's data field |

--- a/examples/data-template.yaml
+++ b/examples/data-template.yaml
@@ -1,0 +1,12 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: example-secret
+  annotations:
+    avp.kubernetes.io/path: "kv/example"
+    avp.kubernetes.io/data-template: |
+      {{ range $Key, $Value := .Data }}
+      {{ $Key }}: {{ $Value | base64encode }}
+      {{ end }}
+      placeholder: {{ .Data.json | jsonPath "{.content}" }}
+type: Opaque

--- a/pkg/kube/template.go
+++ b/pkg/kube/template.go
@@ -55,10 +55,14 @@ func NewTemplate(template unstructured.Unstructured, backend types.Backend) (*Te
 // For both non-Secret resources and Secrets with <placeholder>'s in `stringData`, the value in Vault is emitted as-is
 // For Secret's with <placeholder>'s in `.data`, the value in Vault is emitted as base64
 // For any hard-coded strings that aren't <placeholder>'s, the string is emitted as-is
+//
+// If the `types.AVPDataTemplateAnnotation` annotation is present, the go template from
+// the annotation will be used to generate and replace the contents of the manifest's
+// `data` field.
 func (t *Template) Replace() error {
-	dataTemplate, dataTemplateExists := t.Annotations[types.AVPDataTemplateAnnotation]
+	_, dataTemplateExists := t.Annotations[types.AVPDataTemplateAnnotation]
 	if dataTemplateExists {
-		return replaceFromTemplate(&t.Resource, dataTemplate)
+		return replaceFromTemplate(&t.Resource)
 	}
 
 	var replacerFunc func(string, string, Resource) (interface{}, []error)

--- a/pkg/kube/template.go
+++ b/pkg/kube/template.go
@@ -56,6 +56,11 @@ func NewTemplate(template unstructured.Unstructured, backend types.Backend) (*Te
 // For Secret's with <placeholder>'s in `.data`, the value in Vault is emitted as base64
 // For any hard-coded strings that aren't <placeholder>'s, the string is emitted as-is
 func (t *Template) Replace() error {
+	dataTemplate, dataTemplateExists := t.Annotations[types.AVPDataTemplateAnnotation]
+	if dataTemplateExists {
+		return replaceFromTemplate(&t.Resource, dataTemplate)
+	}
+
 	var replacerFunc func(string, string, Resource) (interface{}, []error)
 
 	switch t.Kind {

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -281,11 +281,16 @@ var dataTemplateFunctionContext template.FuncMap = func() template.FuncMap {
 	return funcMap
 }()
 
-func replaceFromTemplate(r *Resource, rawTemplate string) error {
+func replaceFromTemplate(r *Resource) error {
 	context := struct {
 		Data map[string]interface{}
 	}{
 		Data: r.Data,
+	}
+
+	rawTemplate, rawTemplateExists := r.Annotations[types.AVPDataTemplateAnnotation]
+	if !rawTemplateExists {
+		return fmt.Errorf("annotation %s is not present", types.AVPDataTemplateAnnotation)
 	}
 
 	t, err := template.New(types.AVPDataTemplateAnnotation).Funcs(dataTemplateFunctionContext).Parse(rawTemplate)

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -44,6 +44,7 @@ const (
 	AVPRemoveMissingAnnotation = "avp.kubernetes.io/remove-missing"
 	AVPSecretVersionAnnotation = "avp.kubernetes.io/secret-version"
 	VaultKVVersionAnnotation   = "avp.kubernetes.io/kv-version"
+	AVPDataTemplateAnnotation  = "avp.kubernetes.io/data-template"
 
 	// Kube Constants
 	ArgoCDNamespace = "argocd"


### PR DESCRIPTION
### Description
Introduce support for specifying a go template inside an annotation to generate and replace the contents of a manifest's data field.

Please look at `docs/howitworks.md` to see how the feature works exactly.

My goal was to enable fully dynamic generation of secrets' contents. My problem was that I had to repeat myself every time I created a secret. First I had to create the secret in the vault and specify all the fields it should have. Then in the manifest I used the same field names for clarity. Then for every secret key in the manifest I had to specify the secret's path. Templates now allow me to specify all the fields in the Vault once and have the manifest be generated automatically.

This feature works similarly to [Vault's agent injector](https://www.vaultproject.io/docs/platform/k8s/injector).

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
I went ahead and implemented the functionality but did not talk to the maintainers to see if you'd be interested in introducing it. Would you like to add it or do you have different plans for this plugin?