### PR TITLE
fix: -s do parse secret name/namespace properly

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -34,7 +34,7 @@ func NewClient() (*Client, error) {
 // ReadSecret reads the specified Secret from the defined namespace, otherwise defaults to `argocd`
 // and returns a YAML []byte containing its data, decoded from base64
 func (c *Client) ReadSecret(name string) ([]byte, error) {
-	secretName, secretNamespace := secretNamespaceName(name)
+	secretNamespace, secretName := secretNamespaceName(name)
 	s, err := c.client.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description
Fix of -s do not parse secret name/namespace properly. The variables were misplaced from function return.

**Fixes:** #287 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)