### PR TITLE
feat: Support user-supplied Vault auth paths

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -53,7 +53,8 @@ We also support these AVP specific variables:
 | AVP_GITHUB_TOKEN   | Github token               | Required with `AUTH_TYPE` of `github` |
 | AVP_ROLE_ID        | Vault AppRole Role_ID      | Required with `AUTH_TYPE` of `approle` |
 | AVP_SECRET_ID      | Vault AppRole Secret_ID    | Required with `AUTH_TYPE` of `approle` |
-| AVP_K8S_MOUNT_PATH | Kuberentes Auth Mount PATH | Optional for `AUTH_TYPE` of `k8s` defaults to `auth/kubernetes` |
+| AVP_MOUNT_PATH | Vault Auth Mount PATH | Optional. Defaults to the appropriate path based on `AUTH_TYPE` (i.e, `auth/approle` for AppRole authentication, `auth/github` for Github, `auth/kubernetes` for Kubernetes) |
+| AVP_K8S_MOUNT_PATH | Kuberentes Auth Mount PATH | Optional for `AUTH_TYPE` of `k8s` defaults to `auth/kubernetes`. Takes precedence over `$AVP_MOUNT_PATH` |
 | AVP_K8S_ROLE       | Kuberentes Auth Role      | Required with `AUTH_TYPE` of `k8s` |
 | AVP_K8S_TOKEN_PATH | Path to JWT for Kubernetes Auth  | Optional for `AUTH_TYPE` of `k8s` defaults to `/var/run/secrets/kubernetes.io/serviceaccount/token` |
 | AVP_IBM_API_KEY      | IBM Cloud IAM API Key      | Required with `TYPE` of `ibmsecretsmanager` |

--- a/pkg/auth/vault/approle.go
+++ b/pkg/auth/vault/approle.go
@@ -1,21 +1,31 @@
 package vault
 
 import (
+	"fmt"
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/utils"
 	"github.com/hashicorp/vault/api"
 )
 
+const (
+	approleMountPath = "auth/approle"
+)
+
 // AppRoleAuth is a struct for working with Vault that uses AppRole
 type AppRoleAuth struct {
-	RoleID   string
-	SecretID string
+	RoleID    string
+	SecretID  string
+	MountPath string
 }
 
 // NewAppRoleAuth initalizes a new AppRolAuth with role id and secret id
-func NewAppRoleAuth(roleID, secretID string) *AppRoleAuth {
+func NewAppRoleAuth(roleID, secretID, mountPath string) *AppRoleAuth {
 	appRoleAuth := &AppRoleAuth{
-		RoleID:   roleID,
-		SecretID: secretID,
+		RoleID:    roleID,
+		SecretID:  secretID,
+		MountPath: approleMountPath,
+	}
+	if mountPath != "" {
+		appRoleAuth.MountPath = mountPath
 	}
 
 	return appRoleAuth
@@ -27,7 +37,7 @@ func (a *AppRoleAuth) Authenticate(vaultClient *api.Client) error {
 		"role_id":   a.RoleID,
 		"secret_id": a.SecretID,
 	}
-	data, err := vaultClient.Logical().Write("auth/approle/login", payload)
+	data, err := vaultClient.Logical().Write(fmt.Sprintf("%s/login", a.MountPath), payload)
 	if err != nil {
 		return err
 	}

--- a/pkg/auth/vault/approle_test.go
+++ b/pkg/auth/vault/approle_test.go
@@ -11,7 +11,7 @@ func TestAppRoleLogin(t *testing.T) {
 	cluster, roleID, secretID := helpers.CreateTestAppRoleVault(t)
 	defer cluster.Cleanup()
 
-	appRole := vault.NewAppRoleAuth(roleID, secretID)
+	appRole := vault.NewAppRoleAuth(roleID, secretID, "")
 
 	err := appRole.Authenticate(cluster.Cores[0].Client)
 	if err != nil {

--- a/pkg/auth/vault/github.go
+++ b/pkg/auth/vault/github.go
@@ -1,19 +1,30 @@
 package vault
 
 import (
+	"fmt"
+
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/utils"
 	"github.com/hashicorp/vault/api"
+)
+
+const (
+	githubMountPath = "auth/github"
 )
 
 // GithubAuth is a struct for working with Vault that uses the Github Auth method
 type GithubAuth struct {
 	AccessToken string
+	MountPath   string
 }
 
 // NewGithubAuth initializes a new GithubAuth with token
-func NewGithubAuth(token string) *GithubAuth {
+func NewGithubAuth(token, mountPath string) *GithubAuth {
 	githubAuth := &GithubAuth{
 		AccessToken: token,
+		MountPath:   githubMountPath,
+	}
+	if mountPath != "" {
+		githubAuth.MountPath = mountPath
 	}
 
 	return githubAuth
@@ -25,7 +36,7 @@ func (g *GithubAuth) Authenticate(vaultClient *api.Client) error {
 		"token": g.AccessToken,
 	}
 
-	data, err := vaultClient.Logical().Write("auth/github/login", payload)
+	data, err := vaultClient.Logical().Write(fmt.Sprintf("%s/login", g.MountPath), payload)
 	if err != nil {
 		return err
 	}

--- a/pkg/auth/vault/github_test.go
+++ b/pkg/auth/vault/github_test.go
@@ -12,7 +12,7 @@ func TestGithubLogin(t *testing.T) {
 	cluster := helpers.CreateTestAuthVault(t)
 	defer cluster.Cleanup()
 
-	github := vault.NewGithubAuth("123")
+	github := vault.NewGithubAuth("123", "")
 
 	err := github.Authenticate(cluster.Cores[0].Client)
 	if err != nil {

--- a/pkg/auth/vault/kubernetes.go
+++ b/pkg/auth/vault/kubernetes.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	defaultMountPath   = "auth/kubernetes"
-	serviceAccountFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	kubernetesMountPath = "auth/kubernetes"
+	serviceAccountFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 // K8sAuth TODO
@@ -49,7 +49,7 @@ func (k *K8sAuth) Authenticate(vaultClient *api.Client) error {
 		"jwt":  token,
 	}
 
-	kubeAuthPath := defaultMountPath
+	kubeAuthPath := kubernetesMountPath
 	if k.MountPath != "" {
 		kubeAuthPath = k.MountPath
 	}

--- a/pkg/backends/vault_test.go
+++ b/pkg/backends/vault_test.go
@@ -19,7 +19,7 @@ func TestVaultLogin(t *testing.T) {
 	}
 
 	t.Run("will authenticate with approle", func(t *testing.T) {
-		backend.AuthType = vault.NewAppRoleAuth(roleID, secretID)
+		backend.AuthType = vault.NewAppRoleAuth(roleID, secretID, "")
 
 		err := backend.Login()
 		if err != nil {
@@ -32,7 +32,7 @@ func TestVaultGetSecrets(t *testing.T) {
 	cluster, roleID, secretID := helpers.CreateTestAppRoleVault(t)
 	defer cluster.Cleanup()
 
-	auth := vault.NewAppRoleAuth(roleID, secretID)
+	auth := vault.NewAppRoleAuth(roleID, secretID, "")
 	backend := backends.NewVaultBackend(auth, cluster.Cores[0].Client, "")
 
 	t.Run("will get data from vault with kv1", func(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,11 +44,11 @@ func TestNewConfig(t *testing.T) {
 		},
 		{
 			map[string]interface{}{
-				"AVP_TYPE":            "vault",
-				"AVP_AUTH_TYPE":       "k8s",
-				"AVP_K8S_MOUNT_POINT": "mount_point",
-				"AVP_K8S_ROLE":        "role",
-				"AVP_K8S_TOKEN_PATH":  "toke_path",
+				"AVP_TYPE":           "vault",
+				"AVP_AUTH_TYPE":      "k8s",
+				"AVP_K8S_MOUNT_PATH": "mount_point",
+				"AVP_K8S_ROLE":       "role",
+				"AVP_K8S_TOKEN_PATH": "toke_path",
 			},
 			"*backends.Vault",
 		},
@@ -62,10 +62,19 @@ func TestNewConfig(t *testing.T) {
 		},
 		{
 			map[string]interface{}{
-				"AVP_TYPE":            "vault",
-				"AVP_AUTH_TYPE":       "k8s",
-				"AVP_K8S_MOUNT_POINT": "mount_point",
-				"AVP_K8S_ROLE":        "role",
+				"AVP_TYPE":           "vault",
+				"AVP_AUTH_TYPE":      "k8s",
+				"AVP_K8S_MOUNT_PATH": "mount_point",
+				"AVP_K8S_ROLE":       "role",
+			},
+			"*backends.Vault",
+		},
+		{
+			map[string]interface{}{
+				"AVP_TYPE":       "vault",
+				"AVP_AUTH_TYPE":  "k8s",
+				"AVP_MOUNT_PATH": "mount_point",
+				"AVP_K8S_ROLE":   "role",
 			},
 			"*backends.Vault",
 		},

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -9,6 +9,7 @@ const (
 	EnvAvpGithubToken    = "AVP_GITHUB_TOKEN"
 	EnvAvpK8sRole        = "AVP_K8S_ROLE"
 	EnvAvpK8sMountPath   = "AVP_K8S_MOUNT_PATH"
+	EnvAvpMountPath      = "AVP_MOUNT_PATH"
 	EnvAvpK8sTokenPath   = "AVP_K8S_TOKEN_PATH"
 	EnvAvpIBMAPIKey      = "AVP_IBM_API_KEY"
 	EnvAvpIBMInstanceURL = "AVP_IBM_INSTANCE_URL"


### PR DESCRIPTION
### Description

Add a configuration key `AVP_MOUNT_PATH` that can be used to provide the path to auth to Vault (a generic form of `AVP_K8S_MOUNT_PATH`). 

**Fixes:** #272 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
