### PR TITLE
docs: how to use inline Helm values in ArgoCD manifests

### DIFF
--- a/manifests/argocd-cm.yaml
+++ b/manifests/argocd-cm.yaml
@@ -20,6 +20,13 @@ data:
         command: ["sh", "-c"]
         args: ["helm template ${helm_args} . | argocd-vault-plugin generate -"]
 
+    # This lets you pass a values file as a string as described here:
+    # https://argocd-vault-plugin.readthedocs.io/en/stable/usage/#with-helm
+    - name: argocd-vault-plugin-helm-with-values
+      generate:
+        command: ["bash", "-c"]
+        args: ['helm template -f <(echo "$HELM_VALUES") . | argocd-vault-plugin generate -']
+
     - name: argocd-vault-plugin-kustomize
       generate:
         command: ["sh", "-c"]

--- a/manifests/argocd-cm.yaml
+++ b/manifests/argocd-cm.yaml
@@ -12,20 +12,20 @@ data:
     - name: argocd-vault-plugin-helm
       generate:
         command: ["sh", "-c"]
-        args: ["helm template . | argocd-vault-plugin generate -"]
+        args: ['helm template "$ARGOCD_APP_NAME" . | argocd-vault-plugin generate -']
 
     # This lets you pass args to the Helm invocation as described here: https://argocd-vault-plugin.readthedocs.io/en/stable/usage/#with-helm
     - name: argocd-vault-plugin-helm-with-args
       generate:
         command: ["sh", "-c"]
-        args: ["helm template ${helm_args} . | argocd-vault-plugin generate -"]
+        args: ['helm template "$ARGOCD_APP_NAME" ${helm_args} . | argocd-vault-plugin generate -']
 
     # This lets you pass a values file as a string as described here:
     # https://argocd-vault-plugin.readthedocs.io/en/stable/usage/#with-helm
     - name: argocd-vault-plugin-helm-with-values
       generate:
         command: ["bash", "-c"]
-        args: ['helm template -f <(echo "$HELM_VALUES") . | argocd-vault-plugin generate -']
+        args: ['helm template "$ARGOCD_APP_NAME" -f <(echo "$HELM_VALUES") . | argocd-vault-plugin generate -']
 
     - name: argocd-vault-plugin-kustomize
       generate:


### PR DESCRIPTION
### Description
<!-- please include a brief summary of the changes in this PR -->

This adds documentation on how to use argocd-vault-plugin with Helm values inline in the ArgoCD application manifest (similar to the `--values-literal-file` option or declarative setup here https://github.com/argoproj/argo-cd/blob/cd497c4eec84a47040816a0b04361005c3ce0ee8/docs/operator-manual/application.yaml#L39-L52).

I also changed the example argocd-cm.yml manifest to include `$ARGOCD_APP_NAME` to match the examples from the docs.

**Fixes:** https://github.com/argoproj-labs/argocd-vault-plugin/issues/304 and also https://github.com/argoproj-labs/argocd-vault-plugin/issues/266 (but only for the CLI workflow).

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)
