### PR TITLE
docs: update helm usage

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,7 +47,7 @@ configManagementPlugins: |
       args: ["helm dependency build"]
     generate:
       command: ["sh", "-c"]
-      args: ["helm template $ARGOCD_APP_NAME . | argocd-vault-plugin generate -"]
+      args: ["helm template $ARGOCD_APP_NAME . --install-crds | argocd-vault-plugin generate -"]
 ```
 
 If you want to use Helm along with argocd-vault-plugin and use additional helm args :
@@ -59,7 +59,7 @@ configManagementPlugins: |
       args: ["helm dependency build"]
     generate:
       command: ["sh", "-c"]
-      args: ["helm template $ARGOCD_APP_NAME ${helm_args} . | argocd-vault-plugin generate -"]
+      args: ["helm template $ARGOCD_APP_NAME ${helm_args} . --install-crds | argocd-vault-plugin generate -"]
 ```
 
 Helm args must be defined in the application manifest:


### PR DESCRIPTION
Update helm plugin usage to include install-crds bringing it inline with default ArgoCD helm behaviour (ArgoCD defaults to setting install-crds) 
See: https://github.com/argoproj/argo-cd/pull/3345

### Description
Currently the AVP usage documentation includes a code snippet for how to register the AVP plugin for helm. The used helm template command does not include the flag --install-crds, resulting in ArgoCD helm deployments using AVP not installing CRDs.
This deviates from the ArgoCD default behavior which had this flag specifically added in [PR 3345](https://github.com/argoproj/argo-cd/pull/3345).

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
