### PR TITLE
docs: fix modifiers link

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -50,8 +50,7 @@ Make sure that these environment variables are available to the plugin when runn
 environment variables take precedence over configuration pulled from a Kubernetes Secret or a file.
 
 ### Full List of Supported Parameters
-
-We support all the backend specific environment variables each backend's SDK will accept (e.g, `VAULT_NAMESPACE`, `AWS_REGION`, etc). Refer to the [specific backend's documentation](./backends) for details.
+We support all the backend specific environment variables each backend's SDK will accept (e.g, `VAULT_NAMESPACE`, `AWS_REGION`, etc). Refer to the [specific backend's documentation](../backends) for details.
 
 We also support these AVP specific variables:
 

--- a/docs/howitworks.md
+++ b/docs/howitworks.md
@@ -57,7 +57,7 @@ There are 2 exceptions to this:
 
 - Placeholders that are in base64 format - see [Base64 placeholders](#base64-placeholders) for details
 
-- Modifiers - see [Modifiers](#Modifiers) for details
+- Modifiers - see [Modifiers](#modifiers) for details
 
 ### Types of placeholders
 


### PR DESCRIPTION
### Description
- **modifiers**: link starting with a capital letter only works on GitHub Markdown - not within readthedocs.io
- **backends**: link with single dot will not forward to page on readthedocs.io

_(tested with `Chrome, Windows`, `Firefox, Ubuntu`)_


This PR change will only fix two hyperlink.

**Fixes:**
- fix hyperlink (anker) on same page to Modifiers - using lower case
- fix hyperlink to backends page - using two dots as [already](https://github.com/argoproj-labs/argocd-vault-plugin/blob/b434368a10e088add8c47e0a8be0a003376436a8/docs/installation.md?plain=1#L116) in use

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)