### PR TITLE
docs: use same user in Dockerfile as argocd image

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,7 +99,7 @@ RUN chmod +x ${BIN}
 RUN mv ${BIN} /usr/local/bin
 
 # Switch back to non-root user
-USER argocd
+USER 999
 ```
 After making the plugin available, you must then register the plugin, documentation can be found at <https://argoproj.github.io/argo-cd/user-guide/config-management-plugins/#plugins> on how to do that.
 


### PR DESCRIPTION
### Description
Best practice is to stick with same user (id) as [argoproj/argo-cd](https://github.com/argoproj/argo-cd/blob/f90514587bafcce51e0e2cd6044195fed2266707/Dockerfile#L130).
The example in the documentation will change the user to a name instead of id.

The user still remains the same.

This helps to verify if user runs with securityContext (otherwise it could fail):
```yaml
securityContext:
    runAsUser: 999
```

**Fixes:** <! -- link to issue -->

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)