### PR TITLE
Docs - Add examples for aws secrets manager

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -281,6 +281,39 @@ stringData:
 type: Opaque
 ```
 
+###### Secret in the same account
+
+The 'friendly' name of the secret can be used in this case.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-example
+stringData:
+  sample-secret: <path:test-aws-secret#test-secret>
+type: Opaque
+```
+
+###### Secret in a different account
+
+The arn of the secret needs to be used in this case:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-example
+stringData:
+  sample-secret: <path:arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER>:<SECRET_ID>#<key>>
+type: Opaque
+```
+
+**NOTE**
+For cross account access there is the need to configure the correct permissions between accounts, please check:
+https://aws.amazon.com/premiumsupport/knowledge-center/secrets-manager-share-between-accounts  
+https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_examples_cross.html  
+
 ### GCP Secret Manager
 
 ##### GCP Authentication


### PR DESCRIPTION
### Description
Addition of some examples of usage for cross account stored secrets on AWS Secrets Manager.
The ARN of the secret can be used in this case. Permissions on IAM roles and KMS keys are needed to configure the cross account access, links added

**Fixes:**
Existent examples were vault examples:
https://github.com/argoproj-labs/argocd-vault-plugin/issues/316


### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

