### PR TITLE
Fix: documentation typo from "above" to "below" for key location

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -3,7 +3,7 @@ There are 3 different ways that parameters can be passed along to argocd-vault-p
 ##### Kubernetes Secret
 
 You can define a Secret with the Vault configuration. The keys of the secret's `data`/`stringData`
-should be the exact names given above, case-sensitive:
+should be the exact names given below, case-sensitive:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
### Description
Fixing documentation typo of "above" to be "below" when describing where the keys you can find are.

**Fixes:** there was no issue for this.

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
This is a really simple doc fix.
