### PR TITLE
feat: Add compatibility for ArgoCD 2.4 prefixed environment variables

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -25,6 +25,23 @@ By default, the secret is assumed to be in the `argocd` namespace. However, the 
 
 <b>Note</b>: this requires the `argocd-repo-server` to have a service account token mounted in the standard location.
 
+###### ArgoCD 2.4.0 Environment Variable Prefix
+
+Starting with ArgoCD 2.4.0, environment variables passed into the `init` and `generate` steps are prefixed with `ARGOCD_ENV` to prevent users from setting potentially-sensitive environment variables. All environment variables defined here will be prepended with the new prefix, e.g. `ARGOCD_ENV_AVP_TYPE`. The configuration will honor both prefixed and non-prefixed environment variables, preferring the prefixed variable if both are presented. There are no changes needed to the secret.
+
+```yaml
+apiVersion: v1
+stringData:
+  # Will be renamed to ARGOCD_ENV_AVP_AUTH_TYPE by ArgoCD before reaching the plugin.
+  AVP_AUTH_TYPE: vault
+kind: Secret
+metadata:
+  name: vault-configuration
+  namespace: argocd
+type: Opaque
+```
+
+See the [ArgoCD Upgrade Guide](https://argo-cd.readthedocs.io/en/latest/operator-manual/upgrading/2.3-2.4/#update-plugins-to-use-newly-prefixed-environment-variables) for more information.
 ##### Configuration File
 
 The configuration can be given in a file reachable from the plugin, in any Viper supported format (YAML, JSON, etc.). The keys must match the same names used in the the Kubernetes secret:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -268,6 +268,16 @@ func readConfigOrSecret(secretName, configPath string, v *viper.Viper) error {
 		}
 	}
 
+	// Check for ArgoCD 2.4 prefixed environment variables
+	for _, envVar := range os.Environ() {
+		if strings.HasPrefix(envVar, types.EnvArgoCDPrefix) {
+			envVarPair := strings.SplitN(envVar, "=", 2)
+			key := strings.TrimPrefix(envVarPair[0], types.EnvArgoCDPrefix+"_")
+			val := envVarPair[1]
+			v.Set(key, val)
+		}
+	}
+
 	for k, viperValue := range v.AllSettings() {
 		for _, prefix := range backendPrefixes {
 			if strings.HasPrefix(k, prefix) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,6 +166,23 @@ fDGt+yaf3RaZbVwHSVLzxiXGsu1WQJde3uJeNh5c6z+5
 			},
 			"*backends.OnePasswordConnect",
 		},
+		{
+			map[string]interface{}{
+				"ARGOCD_ENV_AVP_TYPE":         "vault",
+				"ARGOCD_ENV_AVP_AUTH_TYPE":    "github",
+				"ARGOCD_ENV_AVP_GITHUB_TOKEN": "token",
+			},
+			"*backends.Vault",
+		},
+		{
+			map[string]interface{}{
+				"ARGOCD_ENV_AVP_TYPE":         "vault",
+				"AVP_TYPE":                    "not-valid-type",
+				"ARGOCD_ENV_AVP_AUTH_TYPE":    "github",
+				"ARGOCD_ENV_AVP_GITHUB_TOKEN": "token",
+			},
+			"*backends.Vault",
+		},
 	}
 	for _, tc := range testCases {
 		for k, v := range tc.environment {

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -1,6 +1,9 @@
 package types
 
 const (
+	// Environment Variable Prefix
+	EnvArgoCDPrefix = "ARGOCD_ENV"
+
 	// Environment Variable Constants
 	EnvAvpType             = "AVP_TYPE"
 	EnvAvpRoleID           = "AVP_ROLE_ID"


### PR DESCRIPTION
### Description
ArgoCD 2.4 adds a security fix where all environment variables passed to the repo server during the `init` and `generate` phases are prefixed with `ARGOCD_ENV` to prevent users from setting potentially sensitive environment variables. The `argocd-vault-plugin` binary needs to read the required values from env vars with the new prefix. This PR adds another flag to set (`USE_PREFIX`) to switch from reading un-prefixed to reading prefixed env vars.


### Checklist
Please make sure that your PR fulfills the following requirements:
- [ X] Reviewed the guidelines for contributing to this repository
- [ ]X The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ X] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [ X] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ X] Documentation content changes
- [ ] Other (please describe)

### Other information
The ArgoCD 2.4 breaking change was mentioned in #352. I tried looking into ways to have the `config.go` module to read from both the prefixed and unprefixed env vars, but I couldn't get Viper to do that without having to rewrite how those variables read out of the config manager. This was the least intrusive way I could find to make this compatible with 2.4.

I have tested it on our own ArgoCD 2.4 instance with no issues so far.