### PR TITLE
Empty manifests should result in empty output

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -75,10 +75,6 @@ func NewGenerateCommand() *cobra.Command {
 				return err
 			}
 
-			if len(manifests) == 0 {
-				return fmt.Errorf("No manifests")
-			}
-
 			for _, manifest := range manifests {
 
 				template, err := kube.NewTemplate(manifest, cmdConfig.Backend)

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -80,7 +80,7 @@ func TestMain(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expected := "No manifests"
+		expected := ""
 		if !strings.Contains(string(out), expected) {
 			t.Fatalf("expected to contain: %s but got %s", expected, out)
 		}

--- a/docs/howitworks.md
+++ b/docs/howitworks.md
@@ -337,3 +337,23 @@ spec:
       annotations:
         checksum/secret: <path:secrets/data/db#certs | sha256sum>
 ```
+
+### Error Handling
+
+#### Detecting errors in chained commands
+
+By default argocd-vault-plugin will read valid kubernetes YAMLs and replace variables with values from Vault.
+If a previous command failed and outputs nothing to stdout and AVP reads the input from stdin with
+the `-` argument, AVP will forward an empty YAML output downstream. To catch and prevent accientental errors
+in chained commands, please use the `-o pipefail` bash option like so:
+
+```bash
+$ sh -c '((>&2 echo "some error" && exit 1) | argocd-vault-plugin generate - | kubectl diff -f -); echo $?;'
+some error
+0
+
+$ set -o pipefail
+$ sh -c '((>&2 echo "some error" && exit 1) | argocd-vault-plugin generate - | kubectl diff -f -); echo $?;'
+some error
+1
+```


### PR DESCRIPTION
### Description
Removes the if statement to check if manifests are empty and updates the test accordingly

**Fixes:**
#363

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [x] Docs have been added / updated
- [x] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
