### PR TITLE
feat: Use argocd image for sidecar

### DIFF
--- a/manifests/cmp-sidecar/argocd-repo-server.yaml
+++ b/manifests/cmp-sidecar/argocd-repo-server.yaml
@@ -8,6 +8,7 @@ spec:
 
       # Mount SA token for Kubernets auth
       # Note: In 2.4.0 onward, there is a dedicated SA for repo-server (not default)
+      # Note: This is not fully supported for Kubernetes < v1.19
       automountServiceAccountToken: true
 
       # Each of the embedded YAMLs inside cmp-plugin ConfigMap will be mounted into it's respective plugin sidecar
@@ -25,26 +26,12 @@ spec:
         env:
           - name: AVP_VERSION
             value: 1.11.0
-          - name: HELM_VERSION
-            value: 3.9.0
-          - name: KUSTOMIZE_VERSION
-            value: 4.5.5
         command: [sh, -c]
         args:
           - >-
             curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v$(AVP_VERSION)/argocd-vault-plugin_$(AVP_VERSION)_linux_amd64 -o argocd-vault-plugin &&
             chmod +x argocd-vault-plugin &&
-            mv argocd-vault-plugin /custom-tools/ &&
-
-            curl -L https://get.helm.sh/helm-v$(HELM_VERSION)-linux-amd64.tar.gz -o helm.tar.gz &&
-            tar -xvf helm.tar.gz &&
-            chmod +x linux-amd64/helm &&
-            mv linux-amd64/helm /custom-tools &&
-
-            curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(KUSTOMIZE_VERSION)/kustomize_v$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz -o kustomize.tar.gz &&
-            tar -xvf kustomize.tar.gz &&
-            chmod +x kustomize &&
-            mv kustomize /custom-tools
+            mv argocd-vault-plugin /custom-tools/
 
         volumeMounts:
           - mountPath: /custom-tools
@@ -54,7 +41,7 @@ spec:
       containers:
       - name: avp-helm
         command: [/var/run/argocd/argocd-cmp-server]
-        image: registry.access.redhat.com/ubi8
+        image: quay.io/argoproj/argocd:v2.4.0
         securityContext:
           runAsNonRoot: true
           runAsUser: 999
@@ -75,14 +62,11 @@ spec:
           - name: custom-tools
             subPath: argocd-vault-plugin
             mountPath: /usr/local/bin/argocd-vault-plugin
-          - name: custom-tools
-            subPath: helm
-            mountPath: /usr/local/bin/helm
 
       # argocd-vault-plugin with Kustomize
       - name: avp-kustomize
         command: [/var/run/argocd/argocd-cmp-server]
-        image: registry.access.redhat.com/ubi8
+        image: quay.io/argoproj/argocd:v2.4.0
         securityContext:
           runAsNonRoot: true
           runAsUser: 999
@@ -103,14 +87,11 @@ spec:
           - name: custom-tools
             subPath: argocd-vault-plugin
             mountPath: /usr/local/bin/argocd-vault-plugin
-          - name: custom-tools
-            subPath: kustomize
-            mountPath: /usr/local/bin/kustomize
 
       # argocd-vault-plugin with plain YAML
       - name: avp
         command: [/var/run/argocd/argocd-cmp-server]
-        image: registry.access.redhat.com/ubi8
+        image: quay.io/argoproj/argocd:v2.4.0
         securityContext:
           runAsNonRoot: true
           runAsUser: 999

--- a/manifests/cmp-sidecar/kustomization.yaml
+++ b/manifests/cmp-sidecar/kustomization.yaml
@@ -1,6 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+images:
+  - name: quay.io/argoproj/argocd
+    newTag: v2.4.0
+
 # Note: Versions below 2.4.0 will not always work if trying to use AVP with Helm
 # Fixed in https://github.com/argoproj/argo-cd/pull/9319
 resources:


### PR DESCRIPTION
### Description
This allows us to avoid having to manage the versions for helm & kustomize
alongside AVP and argocd, as these binaries are included in the argocd image.

We can add a kustomize images entry to specify / modify the image version from
the kustomization.yaml file.

**Fixes:** #368

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
This is intended to be a draft PR just to illustrate my thought in #368. If the maintainers like it I can make it into an actual PR.
