### PR TITLE
Fix invalid HELM option in usage docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,7 +50,7 @@ configManagementPlugins: |
       args: ["helm dependency build"]
     generate:
       command: ["sh", "-c"]
-      args: ["helm template $ARGOCD_APP_NAME . --install-crds | argocd-vault-plugin generate -"]
+      args: ["helm template $ARGOCD_APP_NAME . --include-crds  | argocd-vault-plugin generate -"]
 ```
 For sidecar configured plugins, add this to `cmp-plugin` ConfigMap, and then [add a sidecar to run it](../installation#initcontainer-and-configuration-via-sidecar):
 ```yaml
@@ -73,7 +73,7 @@ For sidecar configured plugins, add this to `cmp-plugin` ConfigMap, and then [ad
           - sh
           - "-c"
           - |
-            helm template $ARGOCD_APP_NAME --install-crds . |
+            helm template $ARGOCD_APP_NAME --include-crds . |
             argocd-vault-plugin generate -
       lockRepo: false
 ```
@@ -90,7 +90,7 @@ configManagementPlugins: |
       args: ["helm dependency build"]
     generate:
       command: ["sh", "-c"]
-      args: ["helm template $ARGOCD_APP_NAME ${helm_args} . --install-crds | argocd-vault-plugin generate -"]
+      args: ["helm template $ARGOCD_APP_NAME ${helm_args} . --include-crds | argocd-vault-plugin generate -"]
 ```
 For sidecar configured plugins, add this to `cmp-plugin` ConfigMap, and then [add a sidecar to run it](../installation#initcontainer-and-configuration-via-sidecar):
 ```yaml
@@ -113,7 +113,7 @@ For sidecar configured plugins, add this to `cmp-plugin` ConfigMap, and then [ad
           - sh
           - "-c"
           - |
-            helm template $ARGOCD_APP_NAME --install-crds -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_HELM_ARGS} . |
+            helm template $ARGOCD_APP_NAME --include-crds -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_HELM_ARGS} . |
             argocd-vault-plugin generate -
       lockRepo: false
 ```


### PR DESCRIPTION
### Description
Fix usage documentation with valid helm template flag `--include-crds`
https://helm.sh/docs/helm/helm_template/
**Fixes:** #373

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
