### PR TITLE
docs: update argocd-cm manifest

### DIFF
--- a/manifests/cmp-configmap/argocd-cm.yaml
+++ b/manifests/cmp-configmap/argocd-cm.yaml
@@ -12,20 +12,20 @@ data:
     - name: argocd-vault-plugin-helm
       generate:
         command: ["sh", "-c"]
-        args: ['helm template "$ARGOCD_APP_NAME" . | argocd-vault-plugin generate -']
+        args: ['helm template "$ARGOCD_APP_NAME" -n "$ARGOCD_APP_NAMESPACE" . | argocd-vault-plugin generate -']
 
     # This lets you pass args to the Helm invocation as described here: https://argocd-vault-plugin.readthedocs.io/en/stable/usage/#with-helm
     - name: argocd-vault-plugin-helm-with-args
       generate:
         command: ["sh", "-c"]
-        args: ['helm template "$ARGOCD_APP_NAME" ${helm_args} . | argocd-vault-plugin generate -']
+        args: ['helm template "$ARGOCD_APP_NAME" -n "$ARGOCD_APP_NAMESPACE" ${helm_args} . | argocd-vault-plugin generate -']
 
     # This lets you pass a values file as a string as described here:
     # https://argocd-vault-plugin.readthedocs.io/en/stable/usage/#with-helm
     - name: argocd-vault-plugin-helm-with-values
       generate:
         command: ["bash", "-c"]
-        args: ['helm template "$ARGOCD_APP_NAME" -f <(echo "$HELM_VALUES") . | argocd-vault-plugin generate -']
+        args: ['helm template "$ARGOCD_APP_NAME" -n "$ARGOCD_APP_NAMESPACE" -f <(echo "$ARGOCD_ENV_HELM_VALUES") . | argocd-vault-plugin generate -']
 
     - name: argocd-vault-plugin-kustomize
       generate:


### PR DESCRIPTION
Change env variable `HELM_VALUES` to `ARGOCD_ENV_HELM_VALUES` in
manifest to comply with (#356) changes

Add `-n "$ARGOCD_APP_NAMESPACE"` to use with `helm template` to avoid
issues with with `{{.Release.Namespace}}` in helm templates

### Description
There are two issues I encountered when using configmap manifests.
* One is, usage of old env variable name, fixed in #356 
* Second is, not forwarding argocd's application destination namespace to helm.
If helm chart uses `{{.Release.Namespace}}` then deployment uses my argocd namespace, ignoring application configuration.
It can be easily avoided by explicitly forwarding namespace from environmental variables.
`helm template -n "$ARGOCD_APP_NAMESPACE"`

**Fixes:** Documentation.

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [x] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

### Other information
I assume that manifest are treated as part of documentation. 
