### PR TITLE
docs: fix typo in url to vault k8s auth

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -93,7 +93,7 @@ In order to use Kubernetes Authentication a couple of things are required.
     ```
     This role authorizes the "vault-auth" service account in the default namespace and it gives it the default policy.
 
-    You can find the full documentation on configuring Kubernetes Authentication [Here](vaultproject.io/docs/auth/kubernetes#configuration).
+    You can find the full documentation on configuring Kubernetes Authentication [here](https://www.vaultproject.io/docs/auth/kubernetes#configuration).
 
 
 Once Argo CD and Kubernetes are configured, you can then set the required environment variables for the plugin:


### PR DESCRIPTION
### Description
The link was broken because it linked to the GitHub repo:
`https://github.com/argoproj-labs/argocd-vault-plugin/blob/v1.12.0/docs/vaultproject.io/docs/auth/kubernetes#configuration`

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)
