### PR TITLE
AVP panics on reference to deleted secret version in Vault

### DIFF
--- a/pkg/backends/vault.go
+++ b/pkg/backends/vault.go
@@ -73,7 +73,10 @@ func (v *Vault) GetSecrets(path string, version string, annotations map[string]s
 
 	if kvVersion == "2" {
 		if _, ok := secret.Data["data"]; ok {
-			return secret.Data["data"].(map[string]interface{}), nil
+			if secret.Data["data"] != nil {
+				return secret.Data["data"].(map[string]interface{}), nil
+			}
+			return nil, fmt.Errorf("The secret version %s for Vault path %s is nil - is this version of the secret deleted?", version, path)
 		}
 		if len(secret.Data) == 0 {
 			return nil, fmt.Errorf("The Vault path: %s is empty - did you forget to include /data/ in the Vault path for kv-v2?", path)


### PR DESCRIPTION
### Description
The current version of AVP panics when referencing a deleted version of a secret. AVP can handles the case where a path or a version doesn't exist, but Vault return `nil` in the body of the secret when an old version of the secret has been deleted.

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<img width="1423" alt="image" src="https://user-images.githubusercontent.com/29263651/196024349-c6df221f-a67a-4c44-a510-0c8ac4f9ecc8.png">

Running the current version of AVP
```bash
~/Documents/Playground/argocd-vault-plugin on main *1 ?1 ❯ go run main.go generate -c failures/config.yaml failures/ex1.yaml
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 1 [running]:
github.com/argoproj-labs/argocd-vault-plugin/pkg/backends.(*Vault).GetSecrets(0x14000a066f0, {0x1400099e6e6, 0x10}, {0x1400099e6fc, 0x1}, 0x140008ba400?)
        /Users/alexander/Documents/Playground/argocd-vault-plugin/pkg/backends/vault.go:76 +0x544
github.com/argoproj-labs/argocd-vault-plugin/pkg/backends.(*Vault).GetIndividualSecret(0x1400099e6f7?, {0x1400099e6e6?, 0x140005c9208?}, {0x1400099e6f7, 0x4}, {0x1400099e6fc?, 0x0?}, 0x0?)
        /Users/alexander/Documents/Playground/argocd-vault-plugin/pkg/backends/vault.go:95 +0x3c
github.com/argoproj-labs/argocd-vault-plugin/pkg/kube.genericReplacement.func1({0x1400099e6c0, 0x1e, 0x20})
        /Users/alexander/Documents/Playground/argocd-vault-plugin/pkg/kube/util.go:137 +0xa54
regexp.(*Regexp).ReplaceAllFunc.func1({0x0, 0x0, 0x0}, {0x14000129950?, 0x1e?, 0x20?})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/regexp/regexp.go:705 +0x80
regexp.(*Regexp).replaceAll(0x1400014b180, {0x1400099e6c0, 0x1e, 0x20}, {0x0, 0x0}, 0x2, 0x140005c9460)
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/regexp/regexp.go:640 +0x2c0
regexp.(*Regexp).ReplaceAllFunc(0x140005c94f8?, {0x1400099e6c0?, 0x1e?, 0x16?}, 0x140005c94f8?)
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/regexp/regexp.go:704 +0x5c
github.com/argoproj-labs/argocd-vault-plugin/pkg/kube.genericReplacement({0x14000129350, 0x8}, {0x1400099e540, 0x1e}, {{0x14000129380, 0x6}, 0x14000a06150, {0x102b455d0, 0x14000a066f0}, {0x0, ...}, ...})
        /Users/alexander/Documents/Playground/argocd-vault-plugin/pkg/kube/util.go:117 +0x144
github.com/argoproj-labs/argocd-vault-plugin/pkg/kube.secretReplacement({0x14000129350, 0x8}, {0x1400099e540, 0x1e}, {{0x14000129380, 0x6}, 0x14000a06150, {0x102b455d0, 0x14000a066f0}, {0x0, ...}, ...})
        /Users/alexander/Documents/Playground/argocd-vault-plugin/pkg/kube/util.go:221 +0x10c
github.com/argoproj-labs/argocd-vault-plugin/pkg/kube.replaceInner(0x140000703c0, 0x14000881af0, 0x102b15868)
        /Users/alexander/Documents/Playground/argocd-vault-plugin/pkg/kube/util.go:77 +0x4a0
github.com/argoproj-labs/argocd-vault-plugin/pkg/kube.replaceInner(0x140000703c0, 0x140000703d0, 0x102b15868)
        /Users/alexander/Documents/Playground/argocd-vault-plugin/pkg/kube/util.go:53 +0x558
github.com/argoproj-labs/argocd-vault-plugin/pkg/kube.(*Template).Replace(0x140000703c0)
        /Users/alexander/Documents/Playground/argocd-vault-plugin/pkg/kube/template.go:73 +0xb4
github.com/argoproj-labs/argocd-vault-plugin/cmd.NewGenerateCommand.func2(0x14000911180?, {0x14000c7de00?, 0x3?, 0x3?})
        /Users/alexander/Documents/Playground/argocd-vault-plugin/cmd/generate.go:88 +0x584
github.com/spf13/cobra.(*Command).execute(0x14000911180, {0x14000c7ddd0, 0x3, 0x3})
        /Users/alexander/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:856 +0x4c4
github.com/spf13/cobra.(*Command).ExecuteC(0x14000910f00)
        /Users/alexander/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974 +0x354
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/alexander/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902
main.main()
        /Users/alexander/Documents/Playground/argocd-vault-plugin/main.go:10 +0x24
exit status 2
```

With fix:
```bash
~/Documents/Playground/argocd-vault-plugin on main !1 ?1 ❯ go run main.go generate -c failures/config.yaml failures/ex1.yaml       
Error: Replace: could not replace all placeholders in Template:
The secret version 1 for Vault path secret/data/test is nil - is this version of the secret deleted?
Usage:
  argocd-vault-plugin generate <path> [flags]

Flags:
  -c, --config-path string         path to a file containing Vault configuration (YAML, JSON, envfile) to use
  -h, --help                       help for generate
  -s, --secret-name string         name of a Kubernetes Secret in the argocd namespace containing Vault configuration data in the argocd namespace of your ArgoCD host (Only available when used in ArgoCD). The namespace can be overridden by using the format <namespace>:<name>
      --verbose-sensitive-output   enable verbose mode for detailed info to help with debugging. Includes sensitive data (credentials), logged to stderr

exit status 1
```