### PR TITLE
feat: add azure ad workload identity support

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -398,6 +398,15 @@ These are the parameters for Azure:
 AVP_TYPE: azurekeyvault
 ```
 
+##### Azure Workload Identity
+Refer to the [Use an Azure AD workload identity on Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) in the Azure AKS documentation.
+
+These are the parameters for Azure:
+```
+AVP_TYPE: azurekeyvault
+AVP_AUTH_TYPE: workloadIdentity
+```
+
 ##### Examples
 
 ###### Path Annotation

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -407,6 +407,14 @@ AVP_TYPE: azurekeyvault
 AVP_AUTH_TYPE: workloadIdentity
 ```
 
+For Workload Identity, the following environment variables must be present. The Workload Identity webhook will inject these automatically.
+```
+AZURE_AUTHORITY_HOST
+AZURE_CLIENT_ID
+AZURE_FEDERATED_TOKEN_FILE
+AZURE_TENANT_ID
+```
+
 ##### Examples
 
 ###### Path Annotation

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -140,7 +140,7 @@ configManagementPlugins: |
   - name: argocd-vault-plugin-helm
     generate:
       command: ["bash", "-c"]
-      args: ['helm template "$ARGOCD_APP_NAME" -f <(echo "$HELM_VALUES") . | argocd-vault-plugin generate -']
+      args: ['helm template "$ARGOCD_APP_NAME" -f <(echo "$ARGOCD_ENV_HELM_VALUES") . | argocd-vault-plugin generate -']
 ```
 For sidecar configured plugins, add this to `cmp-plugin` ConfigMap, and then [add a sidecar to run it](../installation#initcontainer-and-configuration-via-sidecar):
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	cloud.google.com/go/secretmanager v1.4.0
 	github.com/1Password/connect-sdk-go v1.4.0
 	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible
-	github.com/Azure/go-autorest/autorest v0.11.27 // indirect
+	github.com/Azure/go-autorest/autorest v0.11.27
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11 // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.5 // indirect
 	github.com/IBM/go-sdk-core/v5 v5.10.1
@@ -26,7 +26,7 @@ require (
 	github.com/go-openapi/errors v0.20.2 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.1 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0
 	github.com/hashicorp/go-hclog v1.2.0
@@ -52,6 +52,8 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/yaml v1.3.0
 )
+
+require github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0
 
 require (
 	cloud.google.com/go v0.102.0 // indirect
@@ -159,6 +161,7 @@ require (
 	github.com/joyent/triton-go v1.7.1-0.20200416154420-6801d15b779f // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/keybase/go-crypto v0.0.0-20190403132359-d65b6b94177f // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lib/pq v1.10.6 // indirect
 	github.com/linode/linodego v0.7.1 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 h1:VgSJlZH5u0k2qxSpqyghcFQKmvYckj46uymKK5XzkBM=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -745,6 +747,8 @@ github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188 h1:+eHOFJl1BaXrQxKX+T06f78590z4qA2ZzBTqahsKSE4=
@@ -1263,6 +1267,8 @@ github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/pkg/backends/azurekeyvault.go
+++ b/pkg/backends/azurekeyvault.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/keyvault"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/utils"
 	"path"
+	"os"
 	"strings"
 	"time"
 )
@@ -13,6 +16,15 @@ import (
 // AzureKeyVault is a struct for working with an Azure Key Vault backend
 type AzureKeyVault struct {
 	Client keyvault.BaseClient
+}
+
+// authResult contains the subset of results from token acquisition operation in ConfidentialClientApplication
+// For details see https://aka.ms/msal-net-authenticationresult
+type authResult struct {
+	accessToken    string
+	expiresOn      time.Time
+	grantedScopes  []string
+	declinedScopes []string
 }
 
 // NewAzureKeyVaultBackend initializes a new Azure Key Vault backend
@@ -103,4 +115,72 @@ func (a *AzureKeyVault) GetIndividualSecret(kvpath, secret, version string, anno
 	utils.VerboseToStdErr("Azure Key Vault get versioned secret response %v", data)
 
 	return *data.Value, nil
+}
+
+// ClientAssertionBearerAuthorizerCallback gets an Azure AD token for authentication to Azure using an identity
+func ClientAssertionBearerAuthorizerCallback(tenantID, resource string) (*autorest.BearerAuthorizer, error) {
+	// Azure AD Workload Identity webhook will inject the following env vars
+	// 	AZURE_CLIENT_ID with the clientID set in the service account annotation
+	// 	AZURE_TENANT_ID with the tenantID set in the service account annotation. If not defined, then
+	// 	the tenantID provided via azure-wi-webhook-config for the webhook will be used.
+	// 	AZURE_FEDERATED_TOKEN_FILE is the service account token path
+	// 	AZURE_AUTHORITY_HOST is the AAD authority hostname
+	clientID := os.Getenv("AZURE_CLIENT_ID")
+	tokenFilePath := os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
+	authorityHost := os.Getenv("AZURE_AUTHORITY_HOST")
+
+	utils.VerboseToStdErr("Azure Client ID %v", clientID)
+	utils.VerboseToStdErr("Azure TokenFilePath %v", tokenFilePath)
+	utils.VerboseToStdErr("Azure authorityHost %v", authorityHost)
+	// generate a token using the msal confidential client
+	// this will always generate a new token request to AAD
+
+	cred := confidential.NewCredFromAssertionCallback(func(context.Context, confidential.AssertionRequestOptions) (string, error) {
+		return ReadJWTFromFS(tokenFilePath)
+	})
+	utils.VerboseToStdErr("cred %v", cred)
+	// create the confidential client to request an AAD token
+	confidentialClientApp, err := confidential.New(
+		clientID,
+		cred,
+		confidential.WithAuthority(fmt.Sprintf("%s%s/oauth2/token", authorityHost, tenantID)))
+	if err != nil {
+		utils.VerboseToStdErr("Error in confidental new")
+		return nil, err
+	}
+
+	// trim the suffix / if exists
+	resource = strings.TrimSuffix(resource, "/")
+	// .default needs to be added to the scope
+	if !strings.HasSuffix(resource, ".default") {
+		resource += "/.default"
+	}
+	utils.VerboseToStdErr("resource %v", resource)
+
+	result, err := confidentialClientApp.AcquireTokenByCredential(context.Background(), []string{resource})
+	if err != nil {
+		return nil, err
+	}
+	utils.VerboseToStdErr("access token %v", result.AccessToken)
+
+	return autorest.NewBearerAuthorizer(authResult{
+		accessToken:    result.AccessToken,
+		expiresOn:      result.ExpiresOn,
+		grantedScopes:  result.GrantedScopes,
+		declinedScopes: result.DeclinedScopes,
+	}), nil
+}
+
+// OAuthToken implements the OAuthTokenProvider interface.  It returns the current access token.
+func (ar authResult) OAuthToken() string {
+	return ar.accessToken
+}
+
+// ReadJWTFromFS reads the jwt from file system
+func ReadJWTFromFS(tokenFilePath string) (string, error) {
+	token, err := os.ReadFile(tokenFilePath)
+	if err != nil {
+		return "", err
+	}
+	return string(token), nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/1Password/connect-sdk-go/connect"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/keyvault"
 	kvauth "github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/IBM/go-sdk-core/v5/core"
 	ibmsm "github.com/IBM/secrets-manager-go-sdk/secretsmanagerv1"
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/auth/vault"
@@ -186,13 +187,22 @@ func New(v *viper.Viper, co *Options) (*Config, error) {
 		}
 	case types.AzureKeyVaultbackend:
 		{
-			authorizer, err := kvauth.NewAuthorizerFromEnvironment()
-			if err != nil {
-				return nil, err
+			basicClient := keyvault.New()
+
+			switch authType {
+                        case types.WorkloadIdentityAuth:
+				basicClient.Authorizer = autorest.NewBearerAuthorizerCallback(nil, backends.ClientAssertionBearerAuthorizerCallback)
+				// TODO error handling
+				// TODO add tests
+			default:
+				authorizer, err := kvauth.NewAuthorizerFromEnvironment()
+				if err != nil {
+					return nil, err
+				}
+
+				basicClient.Authorizer = authorizer
 			}
 
-			basicClient := keyvault.New()
-			basicClient.Authorizer = authorizer
 			backend = backends.NewAzureKeyVaultBackend(basicClient)
 		}
 	case types.Sopsbackend:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -192,8 +192,6 @@ func New(v *viper.Viper, co *Options) (*Config, error) {
 			switch authType {
                         case types.WorkloadIdentityAuth:
 				basicClient.Authorizer = autorest.NewBearerAuthorizerCallback(nil, backends.ClientAssertionBearerAuthorizerCallback)
-				// TODO error handling
-				// TODO add tests
 			default:
 				authorizer, err := kvauth.NewAuthorizerFromEnvironment()
 				if err != nil {

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -49,6 +49,7 @@ const (
 	IBMIAMCredentialsType     = "iam_credentials"
 	IBMImportedCertType       = "imported_cert"
 	IBMPublicCertType         = "public_cert"
+	WorkloadIdentityAuth      = "workloadidentity"
 
 	// Supported annotations
 	AVPPathAnnotation          = "avp.kubernetes.io/path"


### PR DESCRIPTION
### Description
Add support for Azure AD Workload Identity. https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview 

**Fixes:** <! -- link to issue -->

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [x] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
First time writing Golang, but I'm gonna figure it out.

A couple of things to note
- I don't often code and I wouldn't know how to test an authentication callback so that is not implemented. Any advice would be appreciated.
- Further work will be needed as the current sdk being used is unsupported as of march of 2023. For now, having the functionality work at all is very helpful. 
- I haven't figured out how to pass environment variables from config.go to a callback in another file, and I figure the callback should be in another file. Comments welcome, but for now I am getting the environment variables in the authentication callback. Of note the environment variables are added to any pod configured to work with workload identity. 
