### PR TITLE
Modify volume name as tmp-dir instead of tmp

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -213,7 +213,7 @@ spec:
           - mountPath: /home/argocd/cmp-server/plugins
             name: plugins
           - mountPath: /tmp
-            name: tmp
+            name: tmp-dir
           
           # Register plugins into sidecar
           - mountPath: /home/argocd/cmp-server/config/plugin.yaml


### PR DESCRIPTION

### Description
With tmp when i try to install with Argocd helm values getting below error when i modify it to tmp-dir its working fine


Error: UPGRADE FAILED: an error occurred while rolling back the release. original upgrade error: cannot patch "gitops-argocd-repo-server" with kind Deployment: Deployment.apps "gitops-argocd-repo-server" is invalid: spec.template.spec.containers[1].volumeMounts[2].name: Not found: "tmp": create: failed to create: Timeout: request did not complete within requested timeout - context deadline exceeded