### PR TITLE
feat: add vault-path validation

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -76,8 +77,15 @@ func NewGenerateCommand() *cobra.Command {
 			}
 
 			for _, manifest := range manifests {
+				var pathValidation *regexp.Regexp
+				if rexp := v.GetString(types.EnvPathValidation); rexp != "" {
+					pathValidation, err = regexp.Compile(rexp)
+					if err != nil {
+						return fmt.Errorf("%s is not a valid regular expression: %s", rexp, err)
+					}
+				}
 
-				template, err := kube.NewTemplate(manifest, cmdConfig.Backend)
+				template, err := kube.NewTemplate(manifest, cmdConfig.Backend, pathValidation)
 				if err != nil {
 					return err
 				}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -224,10 +224,37 @@ func TestMain(t *testing.T) {
 		}
 	})
 
+	t.Run("will return that path validation env is not valid", func(t *testing.T) {
+		args := []string{"../fixtures/input/nonempty"}
+		cmd := NewGenerateCommand()
+
+		// set specific env and register cleanup func
+		os.Setenv("AVP_PATH_VALIDATION", `^\/(?!\/)(.*?)`)
+		t.Cleanup(func() {
+			os.Unsetenv("AVP_PATH_VALIDATION")
+		})
+
+		b := bytes.NewBufferString("")
+		cmd.SetArgs(args)
+		cmd.SetErr(b)
+		cmd.SetOut(bytes.NewBufferString(""))
+		cmd.Execute()
+		out, err := ioutil.ReadAll(b) // Read buffer to bytes
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := "^\\/(?!\\/)(.*?) is not a valid regular expression: error parsing regexp: invalid or unsupported Perl syntax: `(?!`"
+		if !strings.Contains(string(out), expected) {
+			t.Fatalf("expected to contain: %s but got %s", expected, out)
+		}
+	})
+
 	os.Unsetenv("AVP_TYPE")
 	os.Unsetenv("VAULT_ADDR")
 	os.Unsetenv("AVP_AUTH_TYPE")
 	os.Unsetenv("AVP_SECRET_ID")
 	os.Unsetenv("AVP_ROLE_ID")
 	os.Unsetenv("VAULT_SKIP_VERIFY")
+	os.Unsetenv("AVP_PATH_VALIDATION")
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -72,7 +72,7 @@ We support all the backend specific environment variables each backend's SDK wil
 We also support these AVP specific variables:
 
 | Name                       | Description                                         | Notes                                                                                                                                                                        |
-| -------------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -------------------------- |-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | AVP_TYPE                   | The type of Vault backend                           | Supported values: `vault`, `ibmsecretsmanager`, `awssecretsmanager`, `gcpsecretmanager`, `yandexcloudlockbox` and `1passwordconnect`                                         |
 | AVP_KV_VERSION             | The vault secret engine                             | Supported values: `1` and `2` (defaults to 2). KV_VERSION will be ignored if the `avp.kubernetes.io/kv-version` annotation is present in a YAML resource.                    |
 | AVP_AUTH_TYPE              | The type of authentication                          | Supported values: vault: `approle, github, k8s, token`. Only honored for `AVP_TYPE` of `vault`                                                                               |
@@ -89,6 +89,7 @@ We also support these AVP specific variables:
 | AVP_YCL_SERVICE_ACCOUNT_ID | Yandex Cloud Lockbox service account ID             | Required with `TYPE` of `yandexcloudlockbox`                                                                                                                                 |
 | AVP_YCL_KEY_ID             | Yandex Cloud Lockbox service account Key ID         | Required with `TYPE` of `yandexcloudlockbox`                                                                                                                                 |
 | AVP_YCL_PRIVATE_KEY        | Yandex Cloud Lockbox service account private key    | Required with `TYPE` of `yandexcloudlockbox`                                                                                                                                 |
+| AVP_PATH_VALIDATION        | Regular Expression to validate the Vault path       | Optional. Can be used for e.g. to prevent path traversals.                                                                                                                   |
 
 ### Full List of Supported Annotation
 

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -133,6 +133,11 @@ func genericReplacement(key, value string, resource Resource) (_ interface{}, er
 			key := indivSecretMatches[indivPlaceholderSyntax.SubexpIndex("key")]
 			version := indivSecretMatches[indivPlaceholderSyntax.SubexpIndex("version")]
 
+			if resource.PathValidation != nil && !resource.PathValidation.MatchString(path) {
+				err = append(err, fmt.Errorf("the path %s is disallowed by %s restriction", path, types.EnvPathValidation))
+				return match
+			}
+
 			utils.VerboseToStdErr("calling GetIndividualSecret for secret %s from path %s at version %s", key, path, version)
 			secretValue, secretErr = resource.Backend.GetIndividualSecret(path, strings.TrimSpace(key), version, resource.Annotations)
 			if secretErr != nil {

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -25,6 +25,7 @@ const (
 	EnvYCLPrivateKey       = "AVP_YCL_PRIVATE_KEY"
 	EnvAvpUsername         = "AVP_USERNAME"
 	EnvAvpPassword         = "AVP_PASSWORD"
+	EnvPathValidation      = "AVP_PATH_VALIDATION"
 
 	// Backend and Auth Constants
 	VaultBackend              = "vault"


### PR DESCRIPTION
### Description
Users should have the ability to additionally validate vault paths. For example to prevent path traversals.
This can be enabled by setting a regular expression to the new environment variable `AVP_PATH_VALIDATION`.

This pull requests relates to the issue https://github.com/argoproj-labs/argocd-vault-plugin/issues/418.

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
