### PR TITLE
docs: Update plugin usage documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,7 +145,7 @@ configManagementPlugins: |
   - name: argocd-vault-plugin-helm
     generate:
       command: ["bash", "-c"]
-      args: ['helm template "$ARGOCD_APP_NAME" -f <(echo "$HELM_VALUES") . | argocd-vault-plugin generate -']
+      args: ['helm template "$ARGOCD_APP_NAME" -f <(echo "$ARGOCD_ENV_helm_values") . | argocd-vault-plugin generate -']
 ```
 For sidecar configured plugins, add this to `cmp-plugin` ConfigMap, and then [add a sidecar to run it](../installation#initcontainer-and-configuration-via-sidecar):
 ```yaml
@@ -168,7 +168,7 @@ For sidecar configured plugins, add this to `cmp-plugin` ConfigMap, and then [ad
           - bash
           - "-c"
           - |
-            helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE -f <(echo "$ARGOCD_ENV_HELM_VALUES") . |
+            helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE -f <(echo "$ARGOCD_ENV_helm_values") . |
             argocd-vault-plugin generate -
       lockRepo: false
 ```
@@ -180,7 +180,7 @@ Then you can define your Helm values inline in your application manifest:
     plugin:
       name: argocd-vault-plugin-helm
       env:
-        - name: HELM_VALUES
+        - name: helm_values
           value: |
             # non-vault helm values are specified normally
             someValue: lasldkfjlksa


### PR DESCRIPTION
### Description

The CMP-managed plugin documentation for using Helm values was still using a non `ARGOCD_ENV_` prefixed environment variable setup which only works on ArgoCD version before 2.4. This change adds the prefix in the corresponding code examples.

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)
