### PR TITLE
fix(ibmsm): Copy keys from KV types

### DIFF
--- a/pkg/backends/ibmsecretsmanager.go
+++ b/pkg/backends/ibmsecretsmanager.go
@@ -160,7 +160,9 @@ func (d IBMSecretData) GetSecret() (map[string]interface{}, error) {
 		}
 	case *ibmsm.KVSecret:
 		{
-			result["data"] = v.Data
+			for k,v := range(v.Data) {
+				result[k] = v
+			}
 		}
 	default:
 		{
@@ -254,7 +256,9 @@ func (d IBMVersionedSecretData) GetSecret() (map[string]interface{}, error) {
 	case *ibmsm.KVSecretVersion:
 		{
 			if *v.PayloadAvailable {
-				result["data"] = v.Data
+				for k,v := range(v.Data) {
+					result[k] = v
+				}
 			}
 		}
 	default:

--- a/pkg/backends/ibmsecretsmanager.go
+++ b/pkg/backends/ibmsecretsmanager.go
@@ -160,7 +160,7 @@ func (d IBMSecretData) GetSecret() (map[string]interface{}, error) {
 		}
 	case *ibmsm.KVSecret:
 		{
-			for k,v := range(v.Data) {
+			for k, v := range v.Data {
 				result[k] = v
 			}
 		}
@@ -256,7 +256,7 @@ func (d IBMVersionedSecretData) GetSecret() (map[string]interface{}, error) {
 	case *ibmsm.KVSecretVersion:
 		{
 			if *v.PayloadAvailable {
-				for k,v := range(v.Data) {
+				for k, v := range v.Data {
 					result[k] = v
 				}
 			}

--- a/pkg/backends/ibmsecretsmanager_test.go
+++ b/pkg/backends/ibmsecretsmanager_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"testing"
 	"sync"
+	"testing"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	ibmsm "github.com/IBM/secrets-manager-go-sdk/secretsmanagerv2"
@@ -20,10 +20,10 @@ type MockIBMSMClient struct {
 	// It is shared b/w both GetSecret and GetSecretVersion for simplicity, even though each writes to a different field
 	GetSecretLock sync.RWMutex
 
-	GetSecretCalledWith         *ibmsm.GetSecretOptions
-	GetSecretCallCount          int
-	GetSecretVersionCalledWith  *ibmsm.GetSecretVersionOptions
-	GetSecretVersionCallCount   int
+	GetSecretCalledWith        *ibmsm.GetSecretOptions
+	GetSecretCallCount         int
+	GetSecretVersionCalledWith *ibmsm.GetSecretVersionOptions
+	GetSecretVersionCallCount  int
 }
 
 var BIG_GROUP_LEN int = types.IBMMaxPerPage + 1
@@ -155,8 +155,8 @@ func (m *MockIBMSMClient) GetSecret(getSecretOptions *ibmsm.GetSecretOptions) (r
 			"hello": "there",
 		}
 		return &ibmsm.KVSecret{
-			Name:   &name,
-			ID:     &id,
+			Name: &name,
+			ID:   &id,
 			Data: payload,
 		}, nil, nil
 	} else {


### PR DESCRIPTION
### Description

After #517 , AVP was not handling KV secrets correctly, leaving the KV pairs of a `kv` secret in the `data` key of the returned secret's JSON instead of extracting them for individual interpolation like before. This PR restores the original behavior.

A test case was added to verify this issue (fails on `HEAD`) and I've verified in an e2e test that this appears to be fix the issue

**Fixes:** #534 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [X] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
