### PR TITLE
fix: look for vault cached token before login

### DIFF
--- a/pkg/auth/vault/approle.go
+++ b/pkg/auth/vault/approle.go
@@ -33,7 +33,7 @@ func NewAppRoleAuth(roleID, secretID, mountPath string) *AppRoleAuth {
 
 // Authenticate authenticates with Vault using App Role and returns a token
 func (a *AppRoleAuth) Authenticate(vaultClient *api.Client) error {
-	err := utils.CheckExistingToken(vaultClient)
+	err := utils.LoginWithCachedToken(vaultClient)
 	if err != nil {
 		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
 	} else {

--- a/pkg/auth/vault/approle.go
+++ b/pkg/auth/vault/approle.go
@@ -33,6 +33,13 @@ func NewAppRoleAuth(roleID, secretID, mountPath string) *AppRoleAuth {
 
 // Authenticate authenticates with Vault using App Role and returns a token
 func (a *AppRoleAuth) Authenticate(vaultClient *api.Client) error {
+	err := utils.CheckExistingToken(vaultClient)
+	if err != nil {
+		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
+	} else {
+		return nil
+	}
+
 	payload := map[string]interface{}{
 		"role_id":   a.RoleID,
 		"secret_id": a.SecretID,

--- a/pkg/auth/vault/approle_test.go
+++ b/pkg/auth/vault/approle_test.go
@@ -1,9 +1,11 @@
 package vault_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/auth/vault"
+	"github.com/argoproj-labs/argocd-vault-plugin/pkg/utils"
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/helpers"
 )
 
@@ -16,5 +18,24 @@ func TestAppRoleLogin(t *testing.T) {
 	err := appRole.Authenticate(cluster.Cores[0].Client)
 	if err != nil {
 		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	cachedToken, err := utils.ReadExistingToken()
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
+	}
+
+	err = appRole.Authenticate(cluster.Cores[0].Client)
+	if err != nil {
+		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	newCachedToken, err := utils.ReadExistingToken()
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
+	}
+
+	if bytes.Compare(cachedToken, newCachedToken) != 0 {
+		t.Fatalf("expected same token %s but got %s", cachedToken, newCachedToken)
 	}
 }

--- a/pkg/auth/vault/github.go
+++ b/pkg/auth/vault/github.go
@@ -32,7 +32,7 @@ func NewGithubAuth(token, mountPath string) *GithubAuth {
 
 // Authenticate authenticates with Vault and returns a token
 func (g *GithubAuth) Authenticate(vaultClient *api.Client) error {
-	err := utils.CheckExistingToken(vaultClient)
+	err := utils.LoginWithCachedToken(vaultClient)
 	if err != nil {
 		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
 	} else {

--- a/pkg/auth/vault/github.go
+++ b/pkg/auth/vault/github.go
@@ -32,6 +32,13 @@ func NewGithubAuth(token, mountPath string) *GithubAuth {
 
 // Authenticate authenticates with Vault and returns a token
 func (g *GithubAuth) Authenticate(vaultClient *api.Client) error {
+	err := utils.CheckExistingToken(vaultClient)
+	if err != nil {
+		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
+	} else {
+		return nil
+	}
+
 	payload := map[string]interface{}{
 		"token": g.AccessToken,
 	}

--- a/pkg/auth/vault/github_test.go
+++ b/pkg/auth/vault/github_test.go
@@ -1,9 +1,11 @@
 package vault_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/auth/vault"
+	"github.com/argoproj-labs/argocd-vault-plugin/pkg/utils"
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/helpers"
 )
 
@@ -17,5 +19,24 @@ func TestGithubLogin(t *testing.T) {
 	err := github.Authenticate(cluster.Cores[0].Client)
 	if err != nil {
 		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	cachedToken, err := utils.ReadExistingToken()
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
+	}
+
+	err = github.Authenticate(cluster.Cores[0].Client)
+	if err != nil {
+		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	newCachedToken, err := utils.ReadExistingToken()
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
+	}
+
+	if bytes.Compare(cachedToken, newCachedToken) != 0 {
+		t.Fatalf("expected same token %s but got %s", cachedToken, newCachedToken)
 	}
 }

--- a/pkg/auth/vault/kubernetes.go
+++ b/pkg/auth/vault/kubernetes.go
@@ -39,7 +39,7 @@ func NewK8sAuth(role, mountPath, tokenPath string) *K8sAuth {
 
 // Authenticate authenticates with Vault via K8s and returns a token
 func (k *K8sAuth) Authenticate(vaultClient *api.Client) error {
-	err := utils.CheckExistingToken(vaultClient)
+	err := utils.LoginWithCachedToken(vaultClient)
 	if err != nil {
 		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
 	} else {

--- a/pkg/auth/vault/kubernetes.go
+++ b/pkg/auth/vault/kubernetes.go
@@ -39,6 +39,13 @@ func NewK8sAuth(role, mountPath, tokenPath string) *K8sAuth {
 
 // Authenticate authenticates with Vault via K8s and returns a token
 func (k *K8sAuth) Authenticate(vaultClient *api.Client) error {
+	err := utils.CheckExistingToken(vaultClient)
+	if err != nil {
+		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
+	} else {
+		return nil
+	}
+
 	token, err := k.getJWT()
 	if err != nil {
 		return err

--- a/pkg/auth/vault/kubernetes_test.go
+++ b/pkg/auth/vault/kubernetes_test.go
@@ -1,12 +1,14 @@
 package vault_test
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/auth/vault"
+	"github.com/argoproj-labs/argocd-vault-plugin/pkg/utils"
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/helpers"
 )
 
@@ -49,6 +51,25 @@ func TestKubernetesAuth(t *testing.T) {
 	err = k8s.Authenticate(cluster.Cores[0].Client)
 	if err != nil {
 		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	cachedToken, err := utils.ReadExistingToken()
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
+	}
+
+	err = k8s.Authenticate(cluster.Cores[0].Client)
+	if err != nil {
+		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	newCachedToken, err := utils.ReadExistingToken()
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
+	}
+
+	if bytes.Compare(cachedToken, newCachedToken) != 0 {
+		t.Fatalf("expected same token %s but got %s", cachedToken, newCachedToken)
 	}
 
 	err = removeK8sToken()

--- a/pkg/auth/vault/userpass.go
+++ b/pkg/auth/vault/userpass.go
@@ -33,7 +33,7 @@ func NewUserPassAuth(username, password, mountPath string) *UserPassAuth {
 
 // Authenticate authenticates with Vault using userpass and returns a token
 func (a *UserPassAuth) Authenticate(vaultClient *api.Client) error {
-	err := utils.CheckExistingToken(vaultClient)
+	err := utils.LoginWithCachedToken(vaultClient)
 	if err != nil {
 		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
 	} else {

--- a/pkg/auth/vault/userpass.go
+++ b/pkg/auth/vault/userpass.go
@@ -33,6 +33,13 @@ func NewUserPassAuth(username, password, mountPath string) *UserPassAuth {
 
 // Authenticate authenticates with Vault using userpass and returns a token
 func (a *UserPassAuth) Authenticate(vaultClient *api.Client) error {
+	err := utils.CheckExistingToken(vaultClient)
+	if err != nil {
+		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
+	} else {
+		return nil
+	}
+
 	payload := map[string]interface{}{
 		"password": a.Password,
 	}

--- a/pkg/auth/vault/userpass_test.go
+++ b/pkg/auth/vault/userpass_test.go
@@ -1,9 +1,12 @@
 package vault_test
 
 import (
-	"github.com/argoproj-labs/argocd-vault-plugin/pkg/auth/vault"
-	"github.com/argoproj-labs/argocd-vault-plugin/pkg/helpers"
+	"bytes"
 	"testing"
+
+	"github.com/argoproj-labs/argocd-vault-plugin/pkg/auth/vault"
+	"github.com/argoproj-labs/argocd-vault-plugin/pkg/utils"
+	"github.com/argoproj-labs/argocd-vault-plugin/pkg/helpers"
 )
 
 func TestUserPassLogin(t *testing.T) {
@@ -14,5 +17,24 @@ func TestUserPassLogin(t *testing.T) {
 
 	if err := userpass.Authenticate(cluster.Cores[0].Client); err != nil {
 		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	cachedToken, err := utils.ReadExistingToken()
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
+	}
+
+	err = userpass.Authenticate(cluster.Cores[0].Client)
+	if err != nil {
+		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	newCachedToken, err := utils.ReadExistingToken()
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
+	}
+
+	if bytes.Compare(cachedToken, newCachedToken) != 0 {
+		t.Fatalf("expected same token %s but got %s", cachedToken, newCachedToken)
 	}
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -15,28 +15,37 @@ import (
 	"github.com/spf13/viper"
 )
 
-// CheckExistingToken takes a VaultType interface and logs in, while writting the config file
-// And setting the token in the client
-func CheckExistingToken(vaultClient *api.Client) error {
+func ReadExistingToken() ([]byte, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	avpConfigPath := filepath.Join(home, ".avp", "config.json")
 	if _, err := os.Stat(avpConfigPath); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Open our jsonFile
 	jsonFile, err := os.Open(avpConfigPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// defer the closing of our jsonFile so that we can parse it later on
 	defer jsonFile.Close()
 
 	byteValue, err := io.ReadAll(jsonFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return byteValue, nil
+}
+
+// LoginWithCachedToken takes a VaultType interface and tries to log in with the previously cached token,
+// And sets the token in the client
+func LoginWithCachedToken(vaultClient *api.Client) error {
+	byteValue, err := ReadExistingToken()
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -62,7 +62,7 @@ func TestCheckExistingToken(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = utils.CheckExistingToken(client)
+		err = utils.LoginWithCachedToken(client)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -78,11 +78,11 @@ func TestCheckExistingToken(t *testing.T) {
 		}
 	})
 
-	t.Run("will throw an error if no toekn", func(t *testing.T) {
+	t.Run("will throw an error if no token", func(t *testing.T) {
 		ln, client, _ := helpers.CreateTestVault(t)
 		defer ln.Close()
 
-		err := utils.CheckExistingToken(client)
+		err := utils.LoginWithCachedToken(client)
 		if err == nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
### Description
This commit adds the check of the cached vault token before doing the authentication flow over again

**Fixes:** <https://github.com/argoproj-labs/argocd-vault-plugin/issues/536>

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.17` to ensure only the minimum is pulled in.
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
