### PR TITLE
feat: support placeholders in dockerconfigjson auth field

### DIFF
--- a/fixtures/input/nonempty/secret_dockerconfigjson.yaml
+++ b/fixtures/input/nonempty/secret_dockerconfigjson.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  annotations:
+    avp.kubernetes.io/path: secret/testing
+    avp.kubernetes.io/kv-version: "1"
+  name: <name>-dockerconfigjson
+  namespace: <namespace>
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL215LXNlcnZlci5sb2NhbCI6eyJ1c2VybmFtZSI6InVzZXIiLCJwYXNzd29yZCI6Ilx1MDAzY3BhdGg6c2VjcmV0L3Rlc3Rpbmcjc2VjcmV0LXZhci12YWx1ZVx1MDAzZSIsImF1dGgiOiJkWE5sY2pvOGNHRjBhRHB6WldOeVpYUXZkR1Z6ZEdsdVp5TnpaV055WlhRdGRtRnlMWFpoYkhWbFBnPT0ifX19

--- a/fixtures/output/all.yaml
+++ b/fixtures/output/all.yaml
@@ -190,6 +190,18 @@ type: Opaque
 ---
 apiVersion: v1
 data:
+  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL215LXNlcnZlci5sb2NhbCI6eyJhdXRoIjoiZFhObGNqcGtSMVo2WkVNeGQxbFlUbnBrTWpsNVdrRTlQUT09IiwicGFzc3dvcmQiOiJkR1Z6ZEMxd1lYTnpkMjl5WkE9PSIsInVzZXJuYW1lIjoidXNlciJ9fX0=
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/kv-version: "1"
+    avp.kubernetes.io/path: secret/testing
+  name: test-name-dockerconfigjson
+  namespace: test-namespace
+type: kubernetes.io/dockerconfigjson
+---
+apiVersion: v1
+data:
   secret.yaml: c29tZQ==dGVzdC1wYXNzd29yZA==dmFsdWU=
 kind: Secret
 metadata:


### PR DESCRIPTION
### Description
Add support for placeholders in dockerconfigjson pull secrets.

**Fixes:** #152 

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.21` to ensure only the minimum is pulled in.
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
Not mentioned in the issue, but this PR also resolves a problem with go marshaled dockerconfigjson.  By default golang escapes `<>&` to mitigate html injection attacks.  AVP would typically ignore the placeholders because the characters are replaced with their unicode escape sequence equivalents.

```
❯ kubectl create secret docker-registry test --docker-server=https://my-server.local --docker-username='<user>' --docker-password='<pass>' -o yaml --dry-run=client | yq '.data.".dockerconfigjson" | @base64d'

{"auths":{"https://my-server.local":{"username":"\u003cuser\u003e","password":"\u003cpass\u003e","auth":"PHVzZXI+OjxwYXNzPg=="}}}
```
