### PR TITLE
Update manifests to support arm64 nodes

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,9 +82,14 @@ spec:
           - name: AVP_VERSION
             value: "1.18.0"
         args:
-          - >-
+          - |
+            ARCH=$(uname -m)
+            case $ARCH in
+              aarch64) ARCH="arm64";;
+              x86_64) ARCH="amd64";;
+            esac
             wget -O argocd-vault-plugin
-            https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v${AVP_VERSION}/argocd-vault-plugin_${AVP_VERSION}_linux_amd64 &&
+            https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v${AVP_VERSION}/argocd-vault-plugin_${AVP_VERSION}_linux_$ARCH &&
             chmod +x argocd-vault-plugin &&
             mv argocd-vault-plugin /custom-tools/
         volumeMounts:
@@ -193,8 +198,13 @@ spec:
             value: 1.18.0
         command: [sh, -c]
         args:
-          - >-
-            curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v$(AVP_VERSION)/argocd-vault-plugin_$(AVP_VERSION)_linux_amd64 -o argocd-vault-plugin &&
+          - |
+            ARCH=$(uname -m)
+            case $ARCH in
+              aarch64) ARCH="arm64";;
+              x86_64) ARCH="amd64";;
+            esac
+            curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v$(AVP_VERSION)/argocd-vault-plugin_$(AVP_VERSION)_linux_$ARCH -o argocd-vault-plugin &&
             chmod +x argocd-vault-plugin &&
             mv argocd-vault-plugin /custom-tools/
         volumeMounts:

--- a/manifests/cmp-configmap/argocd-repo-server-deploy.yaml
+++ b/manifests/cmp-configmap/argocd-repo-server-deploy.yaml
@@ -31,9 +31,14 @@ spec:
           - name: AVP_VERSION
             value: "1.18.0"
         args:
-          - >-
+          - |
+            ARCH=$(uname -m)
+            case $ARCH in
+              aarch64) ARCH="arm64";;
+              x86_64) ARCH="amd64";;
+            esac
             wget -O argocd-vault-plugin
-            https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v${AVP_VERSION}/argocd-vault-plugin_${AVP_VERSION}_linux_amd64 &&
+            https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v${AVP_VERSION}/argocd-vault-plugin_${AVP_VERSION}_linux_$ARCH &&
             chmod +x argocd-vault-plugin &&
             mv argocd-vault-plugin /custom-tools/
         volumeMounts:

--- a/manifests/cmp-sidecar/argocd-repo-server.yaml
+++ b/manifests/cmp-sidecar/argocd-repo-server.yaml
@@ -28,8 +28,13 @@ spec:
             value: 1.18.0
         command: [sh, -c]
         args:
-          - >-
-            curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v$(AVP_VERSION)/argocd-vault-plugin_$(AVP_VERSION)_linux_amd64 -o argocd-vault-plugin &&
+          - |
+            ARCH=$(uname -m)
+            case $ARCH in
+              aarch64) ARCH="arm64";;
+              x86_64) ARCH="amd64";;
+            esac
+            curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v$(AVP_VERSION)/argocd-vault-plugin_$(AVP_VERSION)_linux_$ARCH -o argocd-vault-plugin &&
             chmod +x argocd-vault-plugin &&
             mv argocd-vault-plugin /custom-tools/
 


### PR DESCRIPTION
The script was downloading the binary for amd64 by default, even when running ArgoCD on arm64 nodes