### PR TITLE
Provide `--verbose` option that does not print sensitive info

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -20,8 +20,8 @@ import (
 func NewGenerateCommand() *cobra.Command {
 	const StdIn = "-"
 	var configPath, secretName string
-	var verboseOutput bool
-	var verboseUnsafe bool
+	var verboseSafe bool
+	var verboseSensitive bool
 	var disableCache bool
 
 	var command = &cobra.Command{
@@ -64,9 +64,12 @@ func NewGenerateCommand() *cobra.Command {
 			}
 
 			v := viper.New()
-			viper.Set("verboseOutput", verboseOutput)
-			viper.Set("verboseUnsafe", verboseUnsafe)
+			viper.Set("verbose", verboseSafe || verboseSensitive)
+			viper.Set("verboseRedact", verboseSafe && !verboseSensitive)
 			viper.Set("disableCache", disableCache)
+			if verboseSensitive {
+				utils.VerboseToStdErr("Running with --verbose-sensitive-output. Sensitive information will be printed to standard error!")
+			}
 			cmdConfig, err := config.New(v, &config.Options{
 				SecretName: secretName,
 				ConfigPath: configPath,
@@ -119,8 +122,8 @@ func NewGenerateCommand() *cobra.Command {
 
 	command.Flags().StringVarP(&configPath, "config-path", "c", "", "path to a file containing Vault configuration (YAML, JSON, envfile) to use")
 	command.Flags().StringVarP(&secretName, "secret-name", "s", "", "name of a Kubernetes Secret in the argocd namespace containing Vault configuration data in the argocd namespace of your ArgoCD host (Only available when used in ArgoCD). The namespace can be overridden by using the format <namespace>:<name>")
-	command.Flags().BoolVar(&verboseOutput, "verboseOutput", false, "enable verboseOutput mode for detailed info to help with debugging. Omits sensitive data (credentials), logged to stderr")
-	command.Flags().BoolVar(&verboseUnsafe, "verboseOutput-sensitive-output", false, "enable verboseOutput mode for detailed info to help with debugging. Includes sensitive data (credentials), logged to stderr")
+	command.Flags().BoolVar(&verboseSafe, "verbose", false, "enable verbose mode for detailed info to help with debugging. Omits sensitive data (credentials), logged to stderr")
+	command.Flags().BoolVar(&verboseSensitive, "verbose-sensitive-output", false, "enable verbose mode for detailed info to help with debugging. Includes sensitive data (credentials), logged to stderr")
 	command.Flags().BoolVar(&disableCache, "disable-token-cache", false, "disable the automatic token cache feature that store tokens locally")
 	return command
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -21,6 +21,7 @@ func NewGenerateCommand() *cobra.Command {
 	const StdIn = "-"
 	var configPath, secretName string
 	var verboseOutput bool
+	var verboseUnsafe bool
 	var disableCache bool
 
 	var command = &cobra.Command{
@@ -64,6 +65,7 @@ func NewGenerateCommand() *cobra.Command {
 
 			v := viper.New()
 			viper.Set("verboseOutput", verboseOutput)
+			viper.Set("verboseUnsafe", verboseUnsafe)
 			viper.Set("disableCache", disableCache)
 			cmdConfig, err := config.New(v, &config.Options{
 				SecretName: secretName,
@@ -117,7 +119,8 @@ func NewGenerateCommand() *cobra.Command {
 
 	command.Flags().StringVarP(&configPath, "config-path", "c", "", "path to a file containing Vault configuration (YAML, JSON, envfile) to use")
 	command.Flags().StringVarP(&secretName, "secret-name", "s", "", "name of a Kubernetes Secret in the argocd namespace containing Vault configuration data in the argocd namespace of your ArgoCD host (Only available when used in ArgoCD). The namespace can be overridden by using the format <namespace>:<name>")
-	command.Flags().BoolVar(&verboseOutput, "verbose-sensitive-output", false, "enable verbose mode for detailed info to help with debugging. Includes sensitive data (credentials), logged to stderr")
+	command.Flags().BoolVar(&verboseOutput, "verboseOutput", false, "enable verboseOutput mode for detailed info to help with debugging. Omits sensitive data (credentials), logged to stderr")
+	command.Flags().BoolVar(&verboseUnsafe, "verboseOutput-sensitive-output", false, "enable verboseOutput mode for detailed info to help with debugging. Includes sensitive data (credentials), logged to stderr")
 	command.Flags().BoolVar(&disableCache, "disable-token-cache", false, "disable the automatic token cache feature that store tokens locally")
 	return command
 }

--- a/pkg/auth/vault/github.go
+++ b/pkg/auth/vault/github.go
@@ -34,7 +34,7 @@ func NewGithubAuth(token, mountPath string) *GithubAuth {
 func (g *GithubAuth) Authenticate(vaultClient *api.Client) error {
 	err := utils.LoginWithCachedToken(vaultClient, "github")
 	if err != nil {
-		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
+		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", utils.SanitizeUnsafe(err))
 	} else {
 		return nil
 	}
@@ -43,18 +43,18 @@ func (g *GithubAuth) Authenticate(vaultClient *api.Client) error {
 		"token": g.AccessToken,
 	}
 
-	utils.VerboseToStdErr("Hashicorp Vault authenticating with Github token %s", g.AccessToken)
+	utils.VerboseToStdErr("Hashicorp Vault authenticating with Github token %s", utils.SanitizeUnsafe(g.AccessToken))
 	data, err := vaultClient.Logical().Write(fmt.Sprintf("%s/login", g.MountPath), payload)
 	if err != nil {
 		return err
 	}
 
-	utils.VerboseToStdErr("Hashicorp Vault authentication response: %v", data)
+	utils.VerboseToStdErr("Hashicorp Vault authentication response: %v", utils.SanitizeUnsafe(data))
 
 	// If we cannot write the Vault token, we'll just have to login next time. Nothing showstopping.
 	err = utils.SetToken(vaultClient, "github", data.Auth.ClientToken)
 	if err != nil {
-		utils.VerboseToStdErr("Hashicorp Vault cannot cache token for future runs: %v", err)
+		utils.VerboseToStdErr("Hashicorp Vault cannot cache token for future runs: %v", utils.SanitizeUnsafe(err))
 	}
 
 	return nil

--- a/pkg/backends/awssecretsmanager.go
+++ b/pkg/backends/awssecretsmanager.go
@@ -70,7 +70,7 @@ func (a *AWSSecretsManager) GetSecrets(path string, version string, annotations 
 		return nil, err
 	}
 
-	utils.VerboseToStdErr("AWS Secrets Manager get secret response %v", result)
+	utils.VerboseToStdErr("AWS Secrets Manager get secret response %v", utils.SanitizeUnsafe(result))
 
 	var dat map[string]interface{}
 

--- a/pkg/backends/azurekeyvault.go
+++ b/pkg/backends/azurekeyvault.go
@@ -73,16 +73,16 @@ func (a *AzureKeyVault) GetSecrets(kvpath string, version string, _ map[string]s
 				if err != nil {
 					return nil, err
 				}
-				utils.VerboseToStdErr("Azure Key Vault get secret response %v", secret)
+				utils.VerboseToStdErr("Azure Key Vault get secret response %v", utils.SanitizeUnsafe(secret))
 				data[name] = *secret.Value
 			} else {
 				verboseOptionalVersion("Azure Key Vault getting secret %s from vault %s", version, name, kvpath)
 				secret, err := client.GetSecret(ctx, name, version, nil)
 				if err != nil || !*secretVersion.Attributes.Enabled {
-					utils.VerboseToStdErr("Azure Key Vault get versioned secret not found %s", err)
+					utils.VerboseToStdErr("Azure Key Vault get versioned secret not found %s", utils.SanitizeUnsafe(err))
 					continue
 				}
-				utils.VerboseToStdErr("Azure Key Vault get versioned secret response %v", secret)
+				utils.VerboseToStdErr("Azure Key Vault get versioned secret response %v", utils.SanitizeUnsafe(secret))
 				data[name] = *secret.Value
 			}
 		}
@@ -110,7 +110,7 @@ func (a *AzureKeyVault) GetIndividualSecret(kvpath, secret, version string, anno
 		return nil, err
 	}
 
-	utils.VerboseToStdErr("Azure Key Vault get individual secret response %v", data)
+	utils.VerboseToStdErr("Azure Key Vault get individual secret response %v", utils.SanitizeUnsafe(data))
 
 	return *data.Value, nil
 }

--- a/pkg/backends/delineasecretsmanager.go
+++ b/pkg/backends/delineasecretsmanager.go
@@ -60,7 +60,7 @@ func (a *DelineaSecretServer) GetSecrets(path string, version string, annotation
 		return nil, fmt.Errorf("could not decode secret json %s", secret_json)
 	}
 
-	utils.VerboseToStdErr("Delinea Secret Server decoding json %s", secret)
+	utils.VerboseToStdErr("Delinea Secret Server decoding json %s", utils.SanitizeUnsafe(secret))
 
 	secret_map := make(map[string]interface{})
 
@@ -69,7 +69,7 @@ func (a *DelineaSecretServer) GetSecrets(path string, version string, annotation
 		secret_map[secret.Fields[index].Slug] = secret.Fields[index].ItemValue
 	}
 
-	utils.VerboseToStdErr("Delinea Secret Server constructed map %s", secret_map)
+	utils.VerboseToStdErr("Delinea Secret Server constructed map %s", utils.SanitizeUnsafe(secret_map))
 	return secret_map, nil
 
 }

--- a/pkg/backends/gcpsecretmanager.go
+++ b/pkg/backends/gcpsecretmanager.go
@@ -57,7 +57,7 @@ func (a *GCPSecretManager) GetSecrets(path string, version string, annotations m
 		return nil, fmt.Errorf("Could not find secret: %v", err)
 	}
 
-	utils.VerboseToStdErr("GCP Secret Manager access secret version response %v", result)
+	utils.VerboseToStdErr("GCP Secret Manager access secret version response %v", utils.SanitizeUnsafe(result))
 
 	data := make(map[string]interface{})
 

--- a/pkg/backends/ibmsecretsmanager.go
+++ b/pkg/backends/ibmsecretsmanager.go
@@ -384,7 +384,7 @@ func (i *IBMSecretsManager) getSecretVersionedOrNot(id, stype, version string) (
 			return nil, fmt.Errorf("Could not retrieve secret %s after %d retries, statuscode %d", id, types.IBMMaxRetries, httpResponse.GetStatusCode())
 		}
 
-		utils.VerboseToStdErr("IBM Cloud Secrets Manager get versioned secret %s HTTP response: %v", id, httpResponse)
+		utils.VerboseToStdErr("IBM Cloud Secrets Manager get versioned secret %s HTTP response: %v", id, utils.SanitizeUnsafe(httpResponse))
 
 		result, err = NewIBMVersionedSecretData(secretVersion).GetSecret()
 		if err != nil {
@@ -402,7 +402,7 @@ func (i *IBMSecretsManager) getSecretVersionedOrNot(id, stype, version string) (
 			return nil, fmt.Errorf("Could not retrieve secret %s after %d retries, statuscode %d", id, types.IBMMaxRetries, httpResponse.GetStatusCode())
 		}
 
-		utils.VerboseToStdErr("IBM Cloud Secrets Manager get unversioned secret %s HTTP response: %v", id, httpResponse)
+		utils.VerboseToStdErr("IBM Cloud Secrets Manager get unversioned secret %s HTTP response: %v", id, utils.SanitizeUnsafe(httpResponse))
 
 		result, err = NewIBMSecretData(secretRes).GetSecret()
 		if err != nil {
@@ -500,7 +500,7 @@ func (i *IBMSecretsManager) listSecretsInGroup(groupId, secretType string) (map[
 			return nil, fmt.Errorf("Could not list secrets for secret group %s: %d\n%s", groupId, details.GetStatusCode(), details.String())
 		}
 
-		utils.VerboseToStdErr("IBM Cloud Secrets Manager list secrets in group HTTP response: %v", details)
+		utils.VerboseToStdErr("IBM Cloud Secrets Manager list secrets in group HTTP response: %v", utils.SanitizeUnsafe(details))
 
 		for _, secret := range res.Secrets {
 			var name, ttype string
@@ -508,7 +508,7 @@ func (i *IBMSecretsManager) listSecretsInGroup(groupId, secretType string) (map[
 
 			data, err := v.GetMetadata()
 			if err != nil {
-				utils.VerboseToStdErr("Skipping a secret in group %s: %s", groupId, err)
+				utils.VerboseToStdErr("Skipping a secret in group %s: %s", groupId, utils.SanitizeUnsafe(err))
 			}
 
 			name = data["name"]

--- a/pkg/backends/keepersecretsmanager.go
+++ b/pkg/backends/keepersecretsmanager.go
@@ -140,7 +140,7 @@ func (a *KeeperSecretsManager) GetSecrets(path string, version string, annotatio
 		}
 	}
 
-	utils.VerboseToStdErr("Keeper Secrets Manager constructed map %s", secretMap)
+	utils.VerboseToStdErr("Keeper Secrets Manager constructed map %s", utils.SanitizeUnsafe(secretMap))
 
 	return secretMap, nil
 

--- a/pkg/backends/kubernetessecret.go
+++ b/pkg/backends/kubernetessecret.go
@@ -43,7 +43,7 @@ func (k *KubernetesSecret) GetSecrets(path string, version string, annotations m
 		out[k] = string(v)
 	}
 
-	utils.VerboseToStdErr("K8s Secret get secret response: %v", out)
+	utils.VerboseToStdErr("K8s Secret get secret response: %v", utils.SanitizeUnsafe(out))
 	return out, nil
 }
 
@@ -51,7 +51,7 @@ func (k *KubernetesSecret) GetSecrets(path string, version string, annotations m
 // Kubernetes Secrets can only be wholly read,
 // So, we use GetSecrets and extract the specific placeholder we want
 func (k *KubernetesSecret) GetIndividualSecret(path, secret, version string, annotations map[string]string) (interface{}, error) {
-	utils.VerboseToStdErr("K8s Secret getting secret %s and key %s", path, secret)
+	utils.VerboseToStdErr("K8s Secret getting secret %s and key %s", path, utils.SanitizeUnsafe(secret))
 	data, err := k.GetSecrets(path, version, annotations)
 	if err != nil {
 		return nil, err

--- a/pkg/backends/localsecretmanager.go
+++ b/pkg/backends/localsecretmanager.go
@@ -32,7 +32,7 @@ func (a *LocalSecretManager) GetSecrets(path string, version string, annotations
 	utils.VerboseToStdErr("Local secret manager getting secret %s at version %s", path, version)
 	cleartext, err := a.Decrypt(path, "yaml")
 
-	utils.VerboseToStdErr("Local secret manager get secret response: %v", cleartext)
+	utils.VerboseToStdErr("Local secret manager get secret response: %v", utils.SanitizeUnsafe(cleartext))
 
 	var dat map[string]interface{}
 

--- a/pkg/backends/onepasswordconnect.go
+++ b/pkg/backends/onepasswordconnect.go
@@ -37,7 +37,7 @@ func (a *OnePasswordConnect) GetSecrets(path string, version string, annotations
 		return nil, err
 	}
 
-	utils.VerboseToStdErr("OnePassword Connect get secret response: %v", result)
+	utils.VerboseToStdErr("OnePassword Connect get secret response: %v", utils.SanitizeUnsafe(result))
 
 	data := make(map[string]interface{})
 

--- a/pkg/backends/vault.go
+++ b/pkg/backends/vault.go
@@ -61,7 +61,7 @@ func (v *Vault) GetSecrets(path string, version string, annotations map[string]s
 		return nil, err
 	}
 
-	utils.VerboseToStdErr("Hashicorp Vault get kv pairs response: %v", secret)
+	utils.VerboseToStdErr("Hashicorp Vault get kv pairs response: %v", utils.SanitizeUnsafe(secret))
 
 	if secret == nil {
 		// Do not mention `version` in error message when it's not honored (KV-V1)

--- a/pkg/backends/yandexcloudlockbox.go
+++ b/pkg/backends/yandexcloudlockbox.go
@@ -41,7 +41,7 @@ func (ycl *YandexCloudLockbox) GetSecrets(secretID string, version string, _ map
 		return nil, err
 	}
 
-	utils.VerboseToStdErr("Yandex Cloud Lockbox get secret response %v", resp)
+	utils.VerboseToStdErr("Yandex Cloud Lockbox get secret response %v", utils.SanitizeUnsafe(resp))
 
 	result := make(map[string]interface{}, len(resp.GetEntries()))
 	for _, v := range resp.GetEntries() {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,14 +1,13 @@
 package config_test
 
 import (
-	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-vault-plugin/pkg/config"
+	"github.com/argoproj-labs/argocd-vault-plugin/pkg/helpers"
 	"github.com/spf13/viper"
 )
 
@@ -267,19 +266,6 @@ func TestNewConfigNoAuthType(t *testing.T) {
 	os.Unsetenv("AVP_TYPE")
 }
 
-// Helper function that captures log output from a function call into a string
-// Adapted from https://stackoverflow.com/a/26806093/170154
-func captureOutput(f func()) string {
-	var buf bytes.Buffer
-	flags := log.Flags()
-	log.SetOutput(&buf)
-	log.SetFlags(0) // don't include any date or time in the logging messages
-	f()
-	log.SetOutput(os.Stderr)
-	log.SetFlags(flags)
-	return buf.String()
-}
-
 func TestNewConfigAwsRegionWarning(t *testing.T) {
 	testCases := []struct {
 		environment  map[string]interface{}
@@ -314,7 +300,7 @@ func TestNewConfigAwsRegionWarning(t *testing.T) {
 		viper.Set("verboseOutput", true)
 
 		v := viper.New()
-		output := captureOutput(func() {
+		output := helpers.CaptureOutput(func() {
 			config, err := config.New(v, &config.Options{})
 			if err != nil {
 				t.Error(err)

--- a/pkg/helpers/test_helpers.go
+++ b/pkg/helpers/test_helpers.go
@@ -1,8 +1,11 @@
 package helpers
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"net"
+	"os"
 	"strconv"
 	"testing"
 
@@ -542,4 +545,17 @@ func (v *MockVault) GetIndividualSecret(path, secret, version string, annotation
 	}
 	num, _ := strconv.ParseInt(version, 10, 0)
 	return v.Data[num-1][secret], nil
+}
+
+// Helper function that captures log output from a function call into a string
+// Adapted from https://stackoverflow.com/a/26806093/170154
+func CaptureOutput(f func()) string {
+	var buf bytes.Buffer
+	flags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0) // don't include any date or time in the logging messages
+	f()
+	log.SetOutput(os.Stderr)
+	log.SetFlags(flags)
+	return buf.String()
 }

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -210,7 +210,7 @@ func configReplacement(key, value string, resource Resource) (interface{}, []err
 
 	// configMap data values must be strings
 
-	utils.VerboseToStdErr("key %s comes from ConfigMap manifest, stringifying value %s to fit", key, value)
+	utils.VerboseToStdErr("key %s comes from ConfigMap manifest, stringifying value %s to fit", key, utils.SanitizeUnsafe(value))
 	return stringify(res), err
 }
 
@@ -219,7 +219,7 @@ func secretReplacement(key, value string, resource Resource) (interface{}, []err
 	if err == nil && genericPlaceholder.Match(decoded) {
 		res, err := genericReplacement(key, string(decoded), resource)
 
-		utils.VerboseToStdErr("key %s comes from Secret manifest, base64 encoding value %s to fit", key, value)
+		utils.VerboseToStdErr("key %s comes from Secret manifest, base64 encoding value %s to fit", key, utils.SanitizeUnsafe(value))
 		return base64.StdEncoding.EncodeToString([]byte(stringify(res))), err
 	}
 

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -142,15 +142,17 @@ func DefaultHttpClient() *http.Client {
 	return httpClient
 }
 
+// VerboseToStdErr formatand prints message to stderr, if either `--verbose` or `--verbose-sensitive-output` were passed.
+// It is a responsibility of the user to call SanitizeUnsafe on all arguments that can contain sensitive data.
 func VerboseToStdErr(format string, message ...interface{}) {
-	if viper.GetBool("verboseOutput") {
+	if viper.GetBool("verbose") {
 		log.Printf(fmt.Sprintf("%s\n", format), message...)
 	}
 }
 
-// SanitizeUnsafe replaces the message data with redacted literal unless `--verbose-sensitive-output` was passed
+// SanitizeUnsafe replaces the message data with redacted literal unless `--verbose-sensitive-output` was passed.
 func SanitizeUnsafe(message interface{}) interface{} {
-	if viper.GetBool("verboseOutput") && !viper.GetBool("verboseUnsafe") {
+	if viper.GetBool("verboseRedact") {
 		messageLen := len(fmt.Sprintf("%s", message))
 		return fmt.Sprintf("***REDACTED(%v characters)***", messageLen)
 	} else {

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -63,7 +63,7 @@ func ReadExistingToken(identifier string) ([]byte, error) {
 func LoginWithCachedToken(vaultClient *api.Client, identifier string) error {
 	if viper.GetBool("disableCache") {
 		return fmt.Errorf("Token cache feature is disabled")
-	}	else {
+	} else {
 		byteValue, err := ReadExistingToken(identifier)
 		if err != nil {
 			return err
@@ -94,7 +94,7 @@ func SetToken(vaultClient *api.Client, identifier string, token string) error {
 
 	if viper.GetBool("disableCache") {
 		return fmt.Errorf("Token cache feature is disabled")
-	}	else {
+	} else {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("Could not access home directory: %s", err.Error())
@@ -145,5 +145,15 @@ func DefaultHttpClient() *http.Client {
 func VerboseToStdErr(format string, message ...interface{}) {
 	if viper.GetBool("verboseOutput") {
 		log.Printf(fmt.Sprintf("%s\n", format), message...)
+	}
+}
+
+// SanitizeUnsafe replaces the message data with redacted literal unless `--verbose-sensitive-output` was passed
+func SanitizeUnsafe(message interface{}) interface{} {
+	if viper.GetBool("verboseOutput") && !viper.GetBool("verboseUnsafe") {
+		messageLen := len(fmt.Sprintf("%s", message))
+		return fmt.Sprintf("***REDACTED(%v characters)***", messageLen)
+	} else {
+		return message
 	}
 }


### PR DESCRIPTION
### Description

`--verbose-sensitive-output` is dangerous to use in production, because the secret values can bubble to ArgoCD UI, archived pod logs, etc, and get exposed to unauthorized personnel.

Introduce `--verbose` option, that redact all potentially sensitive values inserted into the messages.

That way, secrets are not leaked. Administrators get the much needed "traces" of what was executed, same as the details of the safe values the program have worked with.

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Are you adding dependencies? If so, please run `go mod tidy -compat=1.22.7` to ensure only the minimum is pulled in.
- [n/a] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
