### PR TITLE
feat: Enable caching tokens for multiple vault namespaces

### DIFF
--- a/pkg/auth/vault/kubernetes_test.go
+++ b/pkg/auth/vault/kubernetes_test.go
@@ -46,14 +46,14 @@ func TestKubernetesAuth(t *testing.T) {
 		t.Fatalf("error writing token: %s", err)
 	}
 
-	k8s := vault.NewK8sAuth("role", "", string(filepath.Join(saPath, "token")))
+	k8s := vault.NewK8sAuth("role", "", string(filepath.Join(saPath, "token")), "default")
 
 	err = k8s.Authenticate(cluster.Cores[0].Client)
 	if err != nil {
 		t.Fatalf("expected no errors but got: %s", err)
 	}
 
-	cachedToken, err := utils.ReadExistingToken("kubernetes")
+	cachedToken, err := utils.ReadExistingToken("kubernetes_default")
 	if err != nil {
 		t.Fatalf("expected cached vault token but got: %s", err)
 	}
@@ -63,13 +63,29 @@ func TestKubernetesAuth(t *testing.T) {
 		t.Fatalf("expected no errors but got: %s", err)
 	}
 
-	newCachedToken, err := utils.ReadExistingToken("kubernetes")
+	newCachedToken, err := utils.ReadExistingToken("kubernetes_default")
 	if err != nil {
 		t.Fatalf("expected cached vault token but got: %s", err)
 	}
 
 	if bytes.Compare(cachedToken, newCachedToken) != 0 {
 		t.Fatalf("expected same token %s but got %s", cachedToken, newCachedToken)
+	}
+
+	// We create a new connection to a specific namespace and create a different cache
+	namespaceCluster := helpers.CreateTestAuthVault(t)
+	defer namespaceCluster.Cleanup()
+
+	namespaceK8s := vault.NewK8sAuth("role", "", string(filepath.Join(saPath, "token")), "my-other-namespace")
+
+	err = namespaceK8s.Authenticate(namespaceCluster.Cores[0].Client)
+	if err != nil {
+		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	_, err = utils.ReadExistingToken("kubernetes_my-other-namespace")
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
 	}
 
 	err = removeK8sToken()

--- a/pkg/auth/vault/userpass.go
+++ b/pkg/auth/vault/userpass.go
@@ -15,14 +15,16 @@ type UserPassAuth struct {
 	Username  string
 	Password  string
 	MountPath string
+	Namespace string
 }
 
 // NewUserPassAuth initalizes a new NewUserPassAuth with username & password
-func NewUserPassAuth(username, password, mountPath string) *UserPassAuth {
+func NewUserPassAuth(username, password, mountPath string, namespace string) *UserPassAuth {
 	userpassAuth := &UserPassAuth{
 		Username:  username,
 		Password:  password,
 		MountPath: userpassMountPath,
+		Namespace: namespace,
 	}
 	if mountPath != "" {
 		userpassAuth.MountPath = mountPath
@@ -33,7 +35,7 @@ func NewUserPassAuth(username, password, mountPath string) *UserPassAuth {
 
 // Authenticate authenticates with Vault using userpass and returns a token
 func (a *UserPassAuth) Authenticate(vaultClient *api.Client) error {
-	err := utils.LoginWithCachedToken(vaultClient, fmt.Sprintf("userpass_%s", a.Username))
+	err := utils.LoginWithCachedToken(vaultClient, fmt.Sprintf("userpass_%s_%s", a.Namespace, a.Username))
 	if err != nil {
 		utils.VerboseToStdErr("Hashicorp Vault cannot retrieve cached token: %v. Generating a new one", err)
 	} else {
@@ -53,7 +55,7 @@ func (a *UserPassAuth) Authenticate(vaultClient *api.Client) error {
 	utils.VerboseToStdErr("Hashicorp Vault authentication response: %v", data)
 
 	// If we cannot write the Vault token, we'll just have to login next time. Nothing showstopping.
-	if err = utils.SetToken(vaultClient, fmt.Sprintf("userpass_%s", a.Username), data.Auth.ClientToken); err != nil {
+	if err = utils.SetToken(vaultClient, fmt.Sprintf("userpass_%s_%s", a.Namespace, a.Username), data.Auth.ClientToken); err != nil {
 		utils.VerboseToStdErr("Hashicorp Vault cannot cache token for future runs: %v", err)
 	}
 

--- a/pkg/auth/vault/userpass_test.go
+++ b/pkg/auth/vault/userpass_test.go
@@ -14,13 +14,13 @@ func TestUserPassLogin(t *testing.T) {
 	cluster, username, password := helpers.CreateTestUserPassVault(t)
 	defer cluster.Cleanup()
 
-	userpass := vault.NewUserPassAuth(username, password, "")
+	userpass := vault.NewUserPassAuth(username, password, "", "default")
 
 	if err := userpass.Authenticate(cluster.Cores[0].Client); err != nil {
 		t.Fatalf("expected no errors but got: %s", err)
 	}
 
-	cachedToken, err := utils.ReadExistingToken(fmt.Sprintf("userpass_%s", username))
+	cachedToken, err := utils.ReadExistingToken(fmt.Sprintf("userpass_default_%s", username))
 	if err != nil {
 		t.Fatalf("expected cached vault token but got: %s", err)
 	}
@@ -30,7 +30,7 @@ func TestUserPassLogin(t *testing.T) {
 		t.Fatalf("expected no errors but got: %s", err)
 	}
 
-	newCachedToken, err := utils.ReadExistingToken(fmt.Sprintf("userpass_%s", username))
+	newCachedToken, err := utils.ReadExistingToken(fmt.Sprintf("userpass_default_%s", username))
 	if err != nil {
 		t.Fatalf("expected cached vault token but got: %s", err)
 	}
@@ -43,14 +43,14 @@ func TestUserPassLogin(t *testing.T) {
 	secondCluster, secondUsername, secondPassword := helpers.CreateTestUserPassVault(t)
 	defer secondCluster.Cleanup()
 
-	secondUserpass := vault.NewUserPassAuth(secondUsername, secondPassword, "")
+	secondUserpass := vault.NewUserPassAuth(secondUsername, secondPassword, "", "default")
 
 	err = secondUserpass.Authenticate(secondCluster.Cores[0].Client)
 	if err != nil {
 		t.Fatalf("expected no errors but got: %s", err)
 	}
 
-	secondCachedToken, err := utils.ReadExistingToken(fmt.Sprintf("userpass_%s", secondUsername))
+	secondCachedToken, err := utils.ReadExistingToken(fmt.Sprintf("userpass_default_%s", secondUsername))
 	if err != nil {
 		t.Fatalf("expected cached vault token but got: %s", err)
 	}
@@ -58,5 +58,21 @@ func TestUserPassLogin(t *testing.T) {
 	// Both cache should be different
 	if bytes.Compare(cachedToken, secondCachedToken) == 0 {
 		t.Fatalf("expected different tokens but got %s", secondCachedToken)
+	}
+
+	// We create a new connection to a specific namespace and create a different cache
+	namespaceCluster, namespaceUsername, namespacePassword := helpers.CreateTestUserPassVault(t)
+	defer namespaceCluster.Cleanup()
+
+	namespaceUserpass := vault.NewUserPassAuth(namespaceUsername, namespacePassword, "", "my-other-namespace")
+
+	err = namespaceUserpass.Authenticate(namespaceCluster.Cores[0].Client)
+	if err != nil {
+		t.Fatalf("expected no errors but got: %s", err)
+	}
+
+	_, err = utils.ReadExistingToken(fmt.Sprintf("userpass_my-other-namespace_%s", namespaceUsername))
+	if err != nil {
+		t.Fatalf("expected cached vault token but got: %s", err)
 	}
 }

--- a/pkg/backends/vault_test.go
+++ b/pkg/backends/vault_test.go
@@ -19,7 +19,7 @@ func TestVaultLogin(t *testing.T) {
 	}
 
 	t.Run("will authenticate with approle", func(t *testing.T) {
-		backend.AuthType = vault.NewAppRoleAuth(roleID, secretID, "")
+		backend.AuthType = vault.NewAppRoleAuth(roleID, secretID, "", "default")
 
 		err := backend.Login()
 		if err != nil {
@@ -32,7 +32,7 @@ func TestVaultGetSecrets(t *testing.T) {
 	cluster, roleID, secretID := helpers.CreateTestAppRoleVault(t)
 	defer cluster.Cleanup()
 
-	auth := vault.NewAppRoleAuth(roleID, secretID, "")
+	auth := vault.NewAppRoleAuth(roleID, secretID, "", "default")
 	backend := backends.NewVaultBackend(auth, cluster.Cores[0].Client, "")
 
 	t.Run("will get data from vault with kv1", func(t *testing.T) {

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -20,6 +20,7 @@ const (
 	EnvAvpPathPrefix       = "AVP_PATH_PREFIX"
 	EnvAWSRegion           = "AWS_REGION"
 	EnvVaultAddress        = "VAULT_ADDR"
+	EnvVaultNamespace      = "VAULT_NAMESPACE"
 	EnvYCLKeyID            = "AVP_YCL_KEY_ID"
 	EnvYCLServiceAccountID = "AVP_YCL_SERVICE_ACCOUNT_ID"
 	EnvYCLPrivateKey       = "AVP_YCL_PRIVATE_KEY"


### PR DESCRIPTION
### Description

As mentioned in this comment https://github.com/argoproj-labs/argocd-vault-plugin/pull/660#issuecomment-2656306542, the token caching strategy currently does not include support for multiple namespaces when using Vault Enterprise

Right now, it is configured to use different files per auth method and per identifier when possible (roleID for approles, username for user/pass)  
With this PR, it will also include the name of the namespacxe when provided, and use `default` when not

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.22.7` to ensure only the minimum is pulled in.
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
