### PR TITLE
feat: detect & decode url-encoded placeholders, reencode after replacement

### DIFF
--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -196,8 +196,7 @@ func TestGenericReplacement_specificPathWithValidation(t *testing.T) {
 }
 
 func TestGenericReplacement_specificPathUrlEncoded(t *testing.T) {
-	// Test that the specific-path placeholder syntax is used to find/replace placeholders that were url-encoded
-	// along with the generic syntax, since the generic Vault path is defined
+	// Test that the generic replacement function can find/replace placeholders that were url-encoded
 	mv := helpers.MockVault{}
 	mv.LoadData(map[string]interface{}{
 		"namespace": "default ns",
@@ -240,8 +239,7 @@ func TestGenericReplacement_specificPathUrlEncoded(t *testing.T) {
 }
 
 func TestGenericReplacement_specificPathUrlEncodedWithValidation(t *testing.T) {
-	// Test that the specific-path placeholder syntax is used to find/replace placeholders
-	// along with the generic syntax, since the generic Vault path is defined
+	// Test that the generic replacement function can find/replace placeholders that were url-encoded
 	mv := helpers.MockVault{}
 	mv.LoadData(map[string]interface{}{
 		"namespace": "default ns",
@@ -444,6 +442,7 @@ func TestGenericReplacement_multiString(t *testing.T) {
 }
 
 func TestGenericReplacement_multiStringSpecificPathUrlEncoded(t *testing.T) {
+	// Test that multiple url-encoded placeholders in one value string can all be found/replaced.
 	mv := helpers.MockVault{}
 	mv.LoadData(map[string]interface{}{
 		"name": "my app",
@@ -495,7 +494,7 @@ func TestSecretReplacement_SpecificPathUrlEncoded_Base64Encoded(t *testing.T) {
 
 	dummyResource := Resource{
 		TemplateData: map[string]interface{}{
-			"url": `JTNDcGF0aCUzQWJsYWglMkZibGFoJTIzdXNlcm5hbWUlM0U6Ly86JTNDcGF0aCUzQWJsYWglMkZibGFoJTIzcGFzc3dvcmQlM0VAcmVkaXMtbWFzdGVyLmhhcmJvci5zdmMuY2x1c3Rlci5sb2NhbC8wP2lkbGVfdGltZW91dF9zZWNvbmRzPTMwCg==`,
+			"url": `cmVkaXM6Ly8lM0NwYXRoJTNBYmxhaCUyRmJsYWglMjN1c2VybmFtZSUzRTolM0NwYXRoJTNBYmxhaCUyRmJsYWglMjNwYXNzd29yZCUzRUByZWRpcy1tYXN0ZXIuaGFyYm9yLnN2Yy5jbHVzdGVyLmxvY2FsLzA/aWRsZV90aW1lb3V0X3NlY29uZHM9MzAK`,
 		},
 		Data: map[string]interface{}{
 			"password": "test",
@@ -511,7 +510,7 @@ func TestSecretReplacement_SpecificPathUrlEncoded_Base64Encoded(t *testing.T) {
 
 	expected := Resource{
 		TemplateData: map[string]interface{}{
-			"url": "cmVkaXM6Ly86cmVkaXMlNDAxMjNAcmVkaXMtbWFzdGVyLmhhcmJvci5zdmMuY2x1c3Rlci5sb2NhbC8wP2lkbGVfdGltZW91dF9zZWNvbmRzPTMwCg==",
+			"url": "cmVkaXM6Ly9yZWRpczpyZWRpcyU0MDEyM0ByZWRpcy1tYXN0ZXIuaGFyYm9yLnN2Yy5jbHVzdGVyLmxvY2FsLzA/aWRsZV90aW1lb3V0X3NlY29uZHM9MzAK",
 		},
 		Data: map[string]interface{}{
 			"password": "test",

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -484,6 +484,45 @@ func TestGenericReplacement_multiStringSpecificPathUrlEncoded(t *testing.T) {
 	assertSuccessfulReplacement(&dummyResource, &expected, t)
 }
 
+func TestSecretReplacement_SpecificPathUrlEncoded_Base64Encoded(t *testing.T) {
+	// Test that the secret replacement function can find/replace placeholders that were url-encoded
+	// and then base64-encoded.
+	mv := helpers.MockVault{}
+	mv.LoadData(map[string]interface{}{
+		"password": "redis@123",
+		"username": "redis",
+	})
+
+	dummyResource := Resource{
+		TemplateData: map[string]interface{}{
+			"url": `JTNDcGF0aCUzQWJsYWglMkZibGFoJTIzdXNlcm5hbWUlM0U6Ly86JTNDcGF0aCUzQWJsYWglMkZibGFoJTIzcGFzc3dvcmQlM0VAcmVkaXMtbWFzdGVyLmhhcmJvci5zdmMuY2x1c3Rlci5sb2NhbC8wP2lkbGVfdGltZW91dF9zZWNvbmRzPTMwCg==`,
+		},
+		Data: map[string]interface{}{
+			"password": "test",
+			"username": "test",
+		},
+		Backend: &mv,
+		Annotations: map[string]string{
+			(types.AVPPathAnnotation): "",
+		},
+	}
+
+	replaceInner(&dummyResource, &dummyResource.TemplateData, secretReplacement)
+
+	expected := Resource{
+		TemplateData: map[string]interface{}{
+			"url": "cmVkaXM6Ly86cmVkaXMlNDAxMjNAcmVkaXMtbWFzdGVyLmhhcmJvci5zdmMuY2x1c3Rlci5sb2NhbC8wP2lkbGVfdGltZW91dF9zZWNvbmRzPTMwCg==",
+		},
+		Data: map[string]interface{}{
+			"password": "test",
+			"username": "test",
+		},
+		replacementErrors: []error{},
+	}
+
+	assertSuccessfulReplacement(&dummyResource, &expected, t)
+}
+
 func TestGenericReplacement_Base64(t *testing.T) {
 	dummyResource := Resource{
 		TemplateData: map[string]interface{}{


### PR DESCRIPTION
### Description
This PR enables plugin to detect and replace specific path placeholders that were url-encoded to look like `%3Cpath%3Asome%2Fpath%23secret%3E` (for example, by Helm `urlquery` function).

The code finds such escaped placeholders, decodes them, replaces with the secret value and re-encodes the values again.

**Example workflow**:

A Helm chart creates a ConfigMap with the following url using a placeholder value for password from *values.yaml* file:

```yaml
_REDIS_URL_CORE: >-
    redis://:%3Cpath%3Akv%2Fdata%2Fconfig%2Fharbor%2Fredis-pwd%23password%3E@redis-master.harbor.svc.cluster.local/0?idle_timeout_seconds=30
```

The placeholder `%3Cpath%3Akv%2Fdata%2Fconfig%2Fharbor%2Fredis-pwd%23password%3E` is detected and decoded into `<path:kv/data/config/harbor/redis-pwd#password>`.

The decoded placeholder is used to obtain password value "redis@123", which is then URL-encoded again into "redis%40123".

The resulting data in the ConfigMap is:

```yaml
_REDIS_URL_CORE: >-
    redis://:redis%40123@redis-master.harbor.svc.cluster.local/0?idle_timeout_seconds=30
```

Fixes #701

### Checklist
Please make sure that your PR fulfills the following requirements:
- [X] Reviewed the guidelines for contributing to this repository
- [X] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [X] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.22.7` to ensure only the minimum is pulled in.
- [X] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] New tests
- [ ] Build/CI related changes
- [X] Documentation content changes
- [ ] Other (please describe)
