### PR TITLE
feat: Add plain text secret support for AWS Secrets Manager

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -312,6 +312,25 @@ stringData:
 type: Opaque
 ```
 
+###### Plain Text Secrets
+
+AWS Secrets Manager can store plain text (non-JSON) secrets. To retrieve the entire secret value as a raw string (whether it's plain text or JSON), use `SecretString` as the key:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-example
+stringData:
+  # Plain text secret
+  sample-secret: <path:test-plaintext-secret#SecretString>
+  # Or JSON secret as raw string
+  json-as-string: <path:test-json-secret#SecretString>
+type: Opaque
+```
+
+**Note**: Use `#SecretString` to retrieve the raw secret value as a single string. If the secret contains JSON and you want to access individual elements, use `#keyName` (e.g., `<path:test-secret#username>`).
+
 ###### Versioned secrets
 
 ```yaml
@@ -357,9 +376,11 @@ stringData:
 type: Opaque
 ```
 
-###### Retrieving of binary data
+###### Retrieving Binary and Plain Text Data
 
-Since there is no way to set a key for binary type in AWS Secret Manager, set the `<key>` part to `SecretBinary` to retrieve binary data:
+AWS Secrets Manager supports three types of secret values: JSON objects, plain text strings, and binary data.
+
+**For binary data**, use `SecretBinary` as the key:
 
 ```yaml
 apiVersion: v1
@@ -368,6 +389,31 @@ metadata:
   name: aws-example
 stringData:
   sample-secret: <path:arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER>:<SECRET_ID>#SecretBinary>
+type: Opaque
+```
+
+**For plain text (non-JSON) strings**, use `SecretString` as the key:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-example
+stringData:
+  sample-secret: <path:arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER>:<SECRET_ID>#SecretString>
+type: Opaque
+```
+
+**For JSON secrets**, specify the individual key you want to retrieve:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-example
+stringData:
+  username: <path:arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER>:<SECRET_ID>#username>
+  password: <path:arn:aws:secretsmanager:<REGION>:<ACCOUNT_NUMBER>:<SECRET_ID>#password>
 type: Opaque
 ```
 

--- a/pkg/backends/awssecretsmanager.go
+++ b/pkg/backends/awssecretsmanager.go
@@ -77,8 +77,14 @@ func (a *AWSSecretsManager) GetSecrets(path string, version string, annotations 
 	if result.SecretString != nil {
 		err := json.Unmarshal([]byte(*result.SecretString), &dat)
 		if err != nil {
-			return nil, err
+			// If JSON unmarshal fails, treat as plain text
+			utils.VerboseToStdErr("Get plain text value for %v", path)
+			dat = make(map[string]interface{})
+			dat["SecretString"] = *result.SecretString
+			return dat, nil
 		}
+		// Always include SecretString to allow retrieving raw JSON value
+		dat["SecretString"] = *result.SecretString
 	} else if result.SecretBinary != nil {
 		utils.VerboseToStdErr("Get binary value for %v", path)
 		dat = make(map[string]interface{})

--- a/pkg/backends/awssecretsmanager_test.go
+++ b/pkg/backends/awssecretsmanager_test.go
@@ -27,6 +27,18 @@ func (m *mockSecretsManagerClient) GetSecretValue(ctx context.Context, input *se
 		}
 	case "test-binary":
 		data.SecretBinary = []byte("binary-data")
+	case "test-plaintext":
+		string := "This is a plain text secret, not JSON"
+		data.SecretString = &string
+	case "test-empty-plaintext":
+		string := ""
+		data.SecretString = &string
+	case "test-invalid-json":
+		string := "{incomplete json"
+		data.SecretString = &string
+	case "test-json-as-string":
+		string := "{\"username\":\"admin\",\"password\":\"secret123\"}"
+		data.SecretString = &string
 	}
 
 	return data, nil
@@ -42,7 +54,8 @@ func TestAWSSecretManagerGetSecrets(t *testing.T) {
 		}
 
 		expected := map[string]interface{}{
-			"test-secret": "current-value",
+			"test-secret":  "current-value",
+			"SecretString": "{\"test-secret\":\"current-value\"}",
 		}
 
 		if !reflect.DeepEqual(expected, data) {
@@ -70,7 +83,8 @@ func TestAWSSecretManagerGetSecrets(t *testing.T) {
 		}
 
 		expected := map[string]interface{}{
-			"test-secret": "previous-value",
+			"test-secret":  "previous-value",
+			"SecretString": "{\"test-secret\":\"previous-value\"}",
 		}
 
 		if !reflect.DeepEqual(expected, data) {
@@ -90,6 +104,77 @@ func TestAWSSecretManagerGetSecrets(t *testing.T) {
 
 		if !reflect.DeepEqual(expected, data) {
 			t.Errorf("expected: %v, got: %v.", expected, data)
+		}
+	})
+
+	t.Run("Get plain text secret", func(t *testing.T) {
+		data, err := sm.GetSecrets("test-plaintext", "", map[string]string{})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := map[string]interface{}{
+			"SecretString": "This is a plain text secret, not JSON",
+		}
+
+		if !reflect.DeepEqual(expected, data) {
+			t.Errorf("expected: %v, got: %v.", expected, data)
+		}
+	})
+
+	t.Run("Get individual plain text secret", func(t *testing.T) {
+		secret, err := sm.GetIndividualSecret("test-plaintext", "SecretString", "", map[string]string{})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := "This is a plain text secret, not JSON"
+
+		if !reflect.DeepEqual(expected, secret) {
+			t.Errorf("expected: %s, got: %s.", expected, secret)
+		}
+	})
+
+	t.Run("Get empty plain text secret", func(t *testing.T) {
+		data, err := sm.GetSecrets("test-empty-plaintext", "", map[string]string{})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := map[string]interface{}{
+			"SecretString": "",
+		}
+
+		if !reflect.DeepEqual(expected, data) {
+			t.Errorf("expected: %v, got: %v.", expected, data)
+		}
+	})
+
+	t.Run("Get invalid JSON as plain text", func(t *testing.T) {
+		data, err := sm.GetSecrets("test-invalid-json", "", map[string]string{})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := map[string]interface{}{
+			"SecretString": "{incomplete json",
+		}
+
+		if !reflect.DeepEqual(expected, data) {
+			t.Errorf("expected: %v, got: %v.", expected, data)
+		}
+	})
+
+	t.Run("Get valid JSON secret as raw string using SecretString key", func(t *testing.T) {
+		secret, err := sm.GetIndividualSecret("test-json-as-string", "SecretString", "", map[string]string{})
+		if err != nil {
+			t.Fatalf("expected 0 errors but got: %s", err)
+		}
+
+		expected := "{\"username\":\"admin\",\"password\":\"secret123\"}"
+
+		if !reflect.DeepEqual(expected, secret) {
+			t.Errorf("expected: %s, got: %s.", expected, secret)
 		}
 	})
 }


### PR DESCRIPTION
### Description

AWS Secrets Manager natively supports plain text secrets, but the plugin was forcing JSON parsing which caused plain text secrets to fail.

This change allows retrieving plain text secrets using the `SecretString` key, while maintaining full backward compatibility with existing JSON and binary secret handling.

AWS uses `SecretString` already, so it sounds fair to use it for AVP as well: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_CreateSecret.html

Changes:
- Modified GetSecrets to gracefully handle non-JSON secret strings
- Added SecretString key for plain text secret access
- Added comprehensive test coverage for plain text scenarios
- Updated documentation with usage examples

**Fixes:** #710

### Checklist
Please make sure that your PR fulfills the following requirements:
- [x] Reviewed the guidelines for contributing to this repository
- [x] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Tests for the changes have been updated
- [x] Are you adding dependencies? If so, please run `go mod tidy -compat=1.22.7` to ensure only the minimum is pulled in.
- [x] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

### Other information

🤖 Generated with [Claude Code](https://claude.com/claude-code)
