### PR TITLE
docs: remove not used ever and removed config management plugins allowConcurrency & lockRepo

### DIFF
--- a/manifests/cmp-sidecar/cmp-plugin.yaml
+++ b/manifests/cmp-sidecar/cmp-plugin.yaml
@@ -10,7 +10,6 @@ data:
     metadata:
       name: argocd-vault-plugin-kustomize
     spec:
-      allowConcurrency: true
 
       # Note: this command is run _before_ anything is done, therefore the logic is to check
       # if this looks like a Kustomize bundle
@@ -26,7 +25,6 @@ data:
           - sh
           - "-c"
           - "kustomize build . | argocd-vault-plugin generate -"
-      lockRepo: false
   avp-helm.yaml: |
     ---
     apiVersion: argoproj.io/v1alpha1
@@ -34,7 +32,6 @@ data:
     metadata:
       name: argocd-vault-plugin-helm
     spec:
-      allowConcurrency: true
 
       # Note: this command is run _before_ any Helm templating is done, therefore the logic is to check
       # if this looks like a Helm chart
@@ -54,14 +51,12 @@ data:
           - |
             helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_HELM_ARGS} . |
             argocd-vault-plugin generate -
-      lockRepo: false
   avp.yaml: |
     apiVersion: argoproj.io/v1alpha1
     kind: ConfigManagementPlugin
     metadata:
       name: argocd-vault-plugin
     spec:
-      allowConcurrency: true
       discover:
         find:
           command:
@@ -73,5 +68,4 @@ data:
           - argocd-vault-plugin
           - generate
           - "."
-      lockRepo: false
 ---


### PR DESCRIPTION
### Description
* remove not used ever and removed config management plugins allowConcurrency & lockRepo
  * Reason:🧠check ArgoCD  https://github.com/argoproj/argo-cd/pull/10304 PR, removing directly and release in v2.5🧠

### How to review?
* Deploy these manifest examples, without any impact 
* Check current PluginSpec https://github.com/argoproj/argo-cd/blob/master/cmpserver/plugin/config.go#L25, do NOT appear at all

### Checklist
Please make sure that your PR fulfills the following requirements:
- [ ] Reviewed the guidelines for contributing to this repository
- [ ] The commit message follows the [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] Tests for the changes have been updated
- [ ] Are you adding dependencies? If so, please run `go mod tidy -compat=1.22.7` to ensure only the minimum is pulled in.
- [ ] Docs have been added / updated
- [ ] Optional. My organization is added to USERS.md.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

### Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
